### PR TITLE
INFRA-230 - Add rewrite map to facilitate wiki migration

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -47,8 +47,10 @@ For minor changes you can simply edit the markdown online using GitHub. However,
 See [Markdown](markdownrules) for formatting syntax within mkdocs.
 
 
-## Documentation in the wiki
+## Wiki migration
 
 The [CiviCRM wiki](https://wiki.civicrm.org/confluence/display/CRMDOC/CiviCRM+Documentation) has lots of great info but is slowly falling out of use in favor of mkdocs.
 
-
+If you migrate content from the wiki to mkdocs, you may want to setup an HTTP redirect from the wiki
+(`https://wiki.civicrm.org/confluence/display/CRMDOC/{$x}`) to mkdocs (`https://docs.civicrm.org/dev/en/master/{$y}`).
+To do this, add a new row to the [redirects/wiki-crmdoc.txt](redirects/wiki-crmdoc.txt).

--- a/redirects/wiki-crmdoc.txt
+++ b/redirects/wiki-crmdoc.txt
@@ -1,0 +1,1 @@
+Documentation+Infrastructure+Canary develop


### PR DESCRIPTION
With this additional file, it will be possible for a documentation author to take over a wiki page and redirect it here.

Note: On the server `java-prod`, I've deployed my personal branch in `~confluence/src/civicrm-dev-docs/`. As soon as this is merged, we should update it to track `master`.

---
https://issues.civicrm.org/jira/browse/INFRA-230