### PR TITLE
API: code examples broken or with non-standard style

### DIFF
--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -23,7 +23,7 @@ Search for records and return the first or only match. (Note: This
 returns the record in a simplified format which is easy to use)
 
 ## getvalue
-Does a `getsingle` and returns a single value - you need to also set 
+Does a `getsingle` and returns a single value - you need to also set
 `$param['return'] => 'fieldname'`.
 
 ## getcount
@@ -50,17 +50,17 @@ Returns the options for a specified field e.g.
 ```php
 civicrm_api3(
   'contact',
-  'getoptions', 
+  'getoptions',
   array('field' => 'gender_id')
-  ); 
+);
 ```
 
 returns
 
 ```php
 array(
-  1 => 'Female', 
-  2 => 'Male', 
+  1 => 'Female',
+  2 => 'Male',
   3 => 'Transgender'
 )
 ```
@@ -71,7 +71,7 @@ Replace an old set of records with a new or modified set of records.
 (For example, replace the set of "Phone" numbers with a different set of
 "Phone" numbers.).
 
-Warning - REPLACE includes an implicit delete - use with care & test well 
+Warning - REPLACE includes an implicit delete - use with care & test well
 before using in productions
 
 ## <del>setvalue</del>

--- a/docs/api/chaining.md
+++ b/docs/api/chaining.md
@@ -23,48 +23,53 @@ See [api/v3/examples] within the core source code for a plethora of examples
 Note that there are a few supported syntaxes:
 
 ```php
-civicrm('Contact', 'Create', array(
-    'version' => 3,
-    'contact_type' => 'Individual',
-    'display_name' => 'BA Baracus',
-    'api.website.create' => array('url' => 'example.com'));
+civicrm_api('Contact', 'Create', array(
+  'version' => 3,
+  'contact_type' => 'Individual',
+  'display_name' => 'BA Baracus',
+  'api.website.create' => array('url' => 'example.com'),
+));
 ```
 
 is the same as
 
 ```php
-civicrm('Contact', 'Create', array(
-    'version' => 3,
-    'contact_type' => 'Individual',
-    'display_name' => 'BA Baracus',
-    'api.website' => array('url' => 'example.com'));
+civicrm_api('Contact', 'Create', array(
+  'version' => 3,
+  'contact_type' => 'Individual',
+  'display_name' => 'BA Baracus',
+  'api.website' => array('url' => 'example.com'),
+));
 ```
 
 If you have 2 websites to create you can pass them as ids after the `.`
 or an array
 
 ```php
-civicrm('Contact', 'Create', array(
-    'version' => 3,
-    'contact_type' => 'Individual',
-    'display_name' => 'BA Baracus',
-    'api.website.create'    => array('url' => 'example.com',),
-    'api.website.create.2'  => array('url' => 'example.org', ));
+civicrm_api('Contact', 'Create', array(
+  'version' => 3,
+  'contact_type' => 'Individual',
+  'display_name' => 'BA Baracus',
+  'api.website.create' => array('url' => 'example.com'),
+  'api.website.create.2' => array('url' => 'example.org'),
+));
 ```
 
-OR
+or
 
 ```php
-civicrm('Contact', 'Create', array(
-    'version' => 3, 
-    'contact_type' => 'Individual', 
-    'display_name' => 'BA Baracus', 
-    'api.website.create' => array(
-        array('url' => 'example.com', ), 
-        array('url' => 'example.org', )));
+civicrm_api('Contact', 'Create', array(
+  'version' => 3,
+  'contact_type' => 'Individual',
+  'display_name' => 'BA Baracus',
+  'api.website.create' => array(
+    array('url' => 'example.com'),
+    array('url' => 'example.org'),
+  ),
+));
 ```
 
-the format you use on the way in will dictate the format on the way out.
+The format you use on the way in will dictate the format on the way out.
 
 Currently this supports any entity and it will convert to `entity_id` -
 i.e. a PledgePayment inside a contribution will receive the `contribution_id`

--- a/docs/api/params.md
+++ b/docs/api/params.md
@@ -25,15 +25,22 @@ or by ID.
 Example without sequential:
 
 ```php
-$result= civicrm_api('UFMatch','Get', array('version' =>3, 'uf_id' => $user->uid);
-$contactid=$contact['values'][$result['id']]['contact_id'] );
+$result = civicrm_api('UFMatch', 'Get', array(
+  'version' => 3,
+  'uf_id' => $user->uid,
+));
+$contactid = $contact['values'][$result['id']]['contact_id'];
 ```
 
 Example with sequential:
 
 ```php
-$result= civicrm_api('UFMatch','Get', array('version' =>3, 'uf_id' => $user->uid, 'sequential' => 1);
-$contactid=$result['values'][0]['contact_id'] );
+$result = civicrm_api('UFMatch', 'Get', array(
+  'version' => 3,
+  'uf_id' => $user->uid,
+  'sequential' => 1,
+));
+$contactid = $result['values'][0]['contact_id'];
 ```
 
 Note that a single record is returned in this example - whenever a single
@@ -53,7 +60,7 @@ The maximum number of records to return
 Example:
 
 ```php
-civicrm_api('UFMatch','Get', array(
+civicrm_api('UFMatch', 'Get', array(
   'version' => 3,
   'uf_id' => $user->uid,
   'options' => array(
@@ -75,7 +82,7 @@ The numerical offset of the first result record
 Example:
 
 ```php
-civicrm_api('UFMatch','Get', array(
+civicrm_api('UFMatch', 'Get', array(
   'version' => 3,
   'uf_id' => $user->uid,
   'options' => array(
@@ -205,24 +212,24 @@ To set a custom field, or find entities with custom fields of a
 particular value, you typically use a parameter like this:
 
 ```php
-$param['custom_N'] => 'value';
+$params['custom_N'] = 'value';
 ```
 
 To return custom data for an entity, you typically pass a param like the
 following:
 
 ```php
-$param['return.custom_N'] => 1;
+$params['return.custom_N'] = 1;
 ```
 
 *or (depending on which API entity you are querying)*
 ```php
-$param['return'] => 'custom_N';
+$params['return'] = 'custom_N';
 ```
 
 *or*
 ```php
-$param['return'] => 'custom_N,custom_O,custom_P';
+$params['return'] = 'custom_N,custom_O,custom_P';
 ```
 
 For setting custom date fields, (ie CustomValue create), date format is

--- a/docs/api/usage.md
+++ b/docs/api/usage.md
@@ -11,7 +11,7 @@ with the supported actions and parameters:
 | <code>Activity</code>    | An phone call, meeting,<br /> or email message. that <br /> has occurred (or will <br /> occur) at a specific <br /> date and time|<code>create</code><br/><code>get</code><br/><code>delete</code><br/>| <code>activity\_type\_id</code> <br /> <code>source\_contact\_id</code> <br /> <code>assignee\_contact\_id</code>    |
 | <code>Address</code>     | A street-address related <br /> to a contact. |<code>create</code><br/><code>get</code><br/><code>delete</code><br/>| <code>contact\_id</code>,  <br /> <code>street\_address</code> <br /> <code>city</code>  <br /> <code>state\_province\_id</code> <br /> <code>country\_id</code>     |
 
-(*For full, up-to-date details about specific entities and parameters, use the 
+(*For full, up-to-date details about specific entities and parameters, use the
 [API Explorer].*)
 
 [API Explorer]: /api/general/#api-explorer
@@ -64,8 +64,8 @@ This is the most common way to call the API.
 ```php
 try {
   $contacts = civicrm_api3('contact', 'get', array(
-    'first_name'  =>  'Alice',
-    'last_name'   =>  'Roberts',
+    'first_name' => 'Alice',
+    'last_name' => 'Roberts',
   ));
 }
 catch (CiviCRM_API3_Exception $e) {
@@ -79,7 +79,7 @@ for usability:
 
 -   The function `civicrm_api3()` is easier to remember.
 -   The `version => 3` parameter is not required.
--   Errors are reported as PHP exceptions. You may catch the exceptions or 
+-   Errors are reported as PHP exceptions. You may catch the exceptions or
     (by default) allow them to bubble up.
 
 *Note*: If you're writing a Drupal module, a Joomla extension, a WordPress
@@ -97,15 +97,16 @@ This class be used locally or remotely to invoke APIs, as in:
 require_once 'your/civicrm/folder/api/class.api.php';
 $api = new civicrm_api3();
 $apiParams = array(
-   'first_name'   =>  'Alice',
-   'last_name'    =>  'Roberts'
+  'first_name' => 'Alice',
+  'last_name' => 'Roberts'
 );
 if ($api->Contact->Get($apiParams)) {
-   //each key of the result array is an attribute of the api
-    echo "\n contacts found ".$api->count;
-   'contact_type'=>'Individual','return'=>'sort_name,current_employer')) {
-} else {
-    echo $api->errorMsg();
+  //each key of the result array is an attribute of the api
+  echo "\n contacts found ".$api->count;
+  'contact_type'=>'Individual','return'=>'sort_name,current_employer')) {
+}
+else {
+  echo $api->errorMsg();
 }
 ```
 
@@ -163,7 +164,7 @@ For more details, see [AJAX Interface].
 
 [AJAX Interface]: https://wiki.civicrm.org/confluence/display/CRMDOC/AJAX+Interface
 
-The AJAX interface is automatically available for web-pages generated through 
+The AJAX interface is automatically available for web-pages generated through
 CiviCRM (such as standard CiviCRM web-pages, CiviCRM extensions,
 and custom CiviCRM templates).
 
@@ -173,7 +174,7 @@ The AJAX interface could be made available to other parts of the same website
 from php. Please note that the AJAX interface is subject to
 [API Security](https://wiki.civicrm.org/confluence/display/CRMDOC/API+Security)
 and
-[Same Origin Policy](http://en.wikipedia.org/wiki/Same_origin_policy). 
+[Same Origin Policy](http://en.wikipedia.org/wiki/Same_origin_policy).
 To use it from an external site or application, see REST interface documentation.
 
 ## Smarty
@@ -183,7 +184,7 @@ To use it from an external site or application, see REST interface documentation
 Found {$myContactList.count} item(s).
 ```
 
-The smarty call is to add extra information, therefore *create* or *delete* 
+The smarty call is to add extra information, therefore *create* or *delete*
 actions don't make sense in this case.
 
 For more details, see


### PR DESCRIPTION
A lot of the code examples in the API pages are bad.  Many have poor style, so they're a bad example for beginners.  Worse, a number are missing closing parentheses, so they won't even work.  This fixes those.