### PR TITLE
inforporate content from civicrm.org/developer-resources into "community" page

### DIFF
--- a/docs/basics/community.md
+++ b/docs/basics/community.md
@@ -5,7 +5,7 @@ collaborate:
 
 -   [CiviCRM.org](https://civicrm.org)
     -   [Extensions](https://civicrm.org/extensions) publishing
-    -   [Blog posts](https://civicrm.org/blog/) by community members
+    -   [Blog posts](https://civicrm.org/blog/) are written by both the CiviCRM core team and other community members, and cover a wide range of topics. Subscribe to the [RSS feed](https://civicrm.org/blog/feed) to make sure you stay up to date.
     -   [Events](https://civicrm.org/events) -
         meetups, conferences, camps, sprints, webinars
     -   [Job Board](https://civicrm.org/jobs) - Post and find paid work
@@ -13,10 +13,10 @@ collaborate:
     -   [User Guide](https://docs.civicrm.org/user/en/stable/)
     -   [Developer Guide](https://docs.civicrm.org/dev/en/master/)
         *(that you're reading now!)*
--   [Mattermost](https://chat.civicrm.org) - Live discussion
+-   [Mattermost](https://chat.civicrm.org) offers live discussion in chat rooms and direct messages. It's a great place to go for any technical questions. Here, with a bit of luck, you'll often find an instant answer to your question or a pointer in the right direction. Definitely go here if you feel like you are banging your head against a wall.
+-   [StackExchange](http://civicrm.stackexchange.com/) - Question & answer site covering a range of topics relevant to developers and users. It is a great place to find answers to the millions of questions that have already been asked about CiviCRM, and to ask ones that haven't been asked already.
 -   [Jira](https://issues.civicrm.org/jira) - Issue tracking
--   [GitHub](https://github.com/civicrm) - Hosted git repositories
--   [StackExchange](http://civicrm.stackexchange.com/) - Question & answer
+-   [GitHub](https://github.com/civicrm) - Hosted git repositories for the entire CiviCRM codebase, as well as many smaller tools focused on developing CiviCRM.
 -   [Discussion Mailing Lists](https://lists.civicrm.org/lists/)
 -   [Newsletters](https://civicrm.org/civicrm/mailing/subscribe)
 -   Falling out of use


### PR DESCRIPTION
#40 points out that [civicrm.org/developer-resources](https://civicrm.org/developer-resources) has some content missing from the Dev Guide. This PR incorporates that content.