### PR TITLE
Migrate wiki page: Git Commit Messages

### DIFF
--- a/docs/best-practices/commit-messages.md
+++ b/docs/best-practices/commit-messages.md
@@ -1,0 +1,169 @@
+# Git Commit Messages for CiviCRM
+
+# Background
+
+Commit messages appear in many contexts -- e.g. in "git log", "gitk",
+"github", Jenkin's test runs, email notifications, and JIRA's "Commits"
+tab. To ensure that a commit message is easy to read in all contexts, it
+should generally:
+
+-   Start with a meaningful one-line summary.
+-   Include a reference to a JIRA issue.\
+
+Of course, writing a good commit message takes a little time, and some
+folks don't want to spend the time. Shame on you! But... laziness is a
+powerful force, and we're not going to persuade everyone to spend time
+writing beautiful messages. Fortunately, CiviCRM includes some [git
+hooks](http://git-scm.com/book/en/Customizing-Git-Git-Hooks) (like
+[git-footnote](https://github.com/totten/git-footnote)) which can
+automatically enrich your commit message:\
+
+-   Any time you reference a JIRA issue in any part of a commit message,
+    git-footnote will look up the issue and append a hyperlink to the
+    commit message.
+-   If you write a 1-2 word commit message ("CRM-1234" or "fix
+    CRM-1234"), git-footnote will put the JIRA title in the summary
+    line.\
+
+# Examples
+
+When writing commit messages, these are some examples of good/bad
+patterns to consider. (Note: The first line is displayed in bold because
+it's often the only line displayed when browsing through commits.)\
+
+
+
+Your Commit Message
+
+Final Commit Message (after running git-footnote)
+
+Awesome
+
+**CRM-1234 - Subsystem - Summarize what the commit does**
+
+Also write a longer explanation of what the commit does. You don't need
+to give a detailed lesson on how everything works, but it may help to
+describe the corner-case or obscure interaction you were thinking about,
+or it may help to reference other relevant issues (like CRM-4567 or
+CRM-8901). Add whatever seems useful.
+
+**CRM-1234 - Subsystem - **Summarize** what the commit does**
+
+Also write a longer explanation of what the commit does. You don't need
+to give a detailed lesson on how everything works, but it may help to
+describe the corner-case or obscure interaction you were thinking about,
+or it may help to reference other relevant issues (like CRM-4567 or
+CRM-8901). Add whatever seems useful.
+
+---\
+  \* CRM-1234: The Issue Title From JIRA\
+
+[http://issues.civicrm.org/jira/browse/CRM-1234](http://issues.civicrm.org/jira/browse/CRM-1234)\
+  \* CRM-4567: The Other Issue Title From JIRA\
+
+[http://issues.civicrm.org/jira/browse/CRM-4567](http://issues.civicrm.org/jira/browse/CRM-4567)\
+  \* CRM-8901: The Third Issue Title From JIRA\
+
+[http://issues.civicrm.org/jira/browse/CRM-8901](http://issues.civicrm.org/jira/browse/CRM-8901)
+
+Great
+
+**CRM-1234 - Subsystem - **Summarize** what the commit does**
+
+**CRM-1234 - Subsystem - **Summarize** what the commit does**
+
+---
+
+ \* CRM-1234: The Issue Title From JIRA\
+
+[http://issues.civicrm.org/jira/browse/CRM-1234](http://issues.civicrm.org/jira/browse/CRM-1234)
+
+Good
+
+**CRM-1234 - **Summarize** what the commit does**
+
+**CRM-1234 - **Summarize** what the commit does**
+
+---
+
+ \* CRM-1234: The Issue Title From JIRA\
+
+[http://issues.civicrm.org/jira/browse/CRM-1234](http://issues.civicrm.org/jira/browse/CRM-1234)
+
+OK
+
+**CRM-1234**
+
+**CRM-1234 - The Issue Title From JIRA\
+**
+
+[http://issues.civicrm.org/jira/browse/CRM-1234](http://issues.civicrm.org/jira/browse/CRM-1234)
+
+OK
+
+**fix CRM-1234**
+
+**fix CRM-1234 - The Issue Title From JIRA**
+
+[http://issues.civicrm.org/jira/browse/CRM-1234](http://issues.civicrm.org/jira/browse/CRM-1234) **\
+**
+
+OK
+
+**Subsystem - **Summarize** what the commit does**
+
+**Subsystem - Summarize what the commit does**
+
+So-So
+
+****Summarize** what the commit does**
+
+******Summarize**** what the commit does**
+
+Terrible
+
+**cleanup**
+
+**cleanup**
+
+\
+
+# Hook Installation
+
+To take advantage of the automatic formatting on commit messages, you
+must enable CiviCRM's [git
+hooks](http://git-scm.com/book/en/Customizing-Git-Git-Hooks). The
+"gitify" tool (discussed in [Contributing to CiviCRM using
+GitHub](/confluence/display/CRMDOC/Contributing+to+CiviCRM+using+GitHub))
+will create the hooks if you include the "--hooks" option. If you didn't
+originally use "gitify" with the "–hooks" option, then just re-run
+"gitify" and add the "--hooks" option this time. ("gitify" won't replace
+your existing git repos, but it will register hooks on them.)\
+
+If you cannot or do not want to use "gitify", then you can [review the
+standard git hooks included with
+CiviCRM](https://github.com/civicrm/civicrm-core/tree/master/tools/scripts/git)
+and write your own. Be sure to look at each of your git repositories
+("civicrm-core", "civicrm-drupal", etc) to ensure the hooks are
+registered.\
+
+# FAQ
+
+-   **Q: What if I write something that doesn't have a JIRA issue?**
+-   A: It's generally good practice to create a JIRA issue before
+    working on a problem, then reference the issue in the commit
+    message. However, if that seems inappropriate, then make reference
+    to the general **area or subsystem** instead.
+-   **Q: What is an "area" or "subsystem"?**\
+
+-   The term is purposefully ambiguous - it's difficult to think of a
+    hard rule, and it seems to depend on how many lines/files/functions
+    were touched. It might be the name of a class, a function, a
+    template, a directory, or a component. The goal is the provide some
+    clue to the future reader so that she can guess which commits would
+    be relevant to the bug/issue she's investigating. However, here are
+    some examples of commit-messages that mention the area/subsystem:\
+    -   "CRM\_Core\_Error - Cleanup log format"
+    -   "api/v3/Email - Remove unused variable"
+    -   "api/v3 - Fix various comment blocks"
+    -   "civicrm/contact/view - fix 5.4 static errors"

--- a/docs/best-practices/commit-messages.md
+++ b/docs/best-practices/commit-messages.md
@@ -1,169 +1,210 @@
-# Git Commit Messages for CiviCRM
+# Writing good commit messages in git
 
-# Background
+## Basic standards
 
-Commit messages appear in many contexts -- e.g. in "git log", "gitk",
-"github", Jenkin's test runs, email notifications, and JIRA's "Commits"
+Commit messages appear in many contexts -- e.g. in `git log`, `gitk`,
+GitHub, Jenkin's test runs, email notifications, and JIRA's *Commits*
 tab. To ensure that a commit message is easy to read in all contexts, it
 should generally:
 
 -   Start with a meaningful one-line summary.
--   Include a reference to a JIRA issue.\
+-   Include a reference to a JIRA issue.
 
-Of course, writing a good commit message takes a little time, and some
-folks don't want to spend the time. Shame on you! But... laziness is a
-powerful force, and we're not going to persuade everyone to spend time
-writing beautiful messages. Fortunately, CiviCRM includes some [git
-hooks](http://git-scm.com/book/en/Customizing-Git-Git-Hooks) (like
-[git-footnote](https://github.com/totten/git-footnote)) which can
-automatically enrich your commit message:\
+## Using git-footnote to save time
+
+To make the process of writing useful commit messages faster and easier,
+we have a tool called
+[git-footnote](https://github.com/totten/git-footnote)
+that automatically adds details to your commit message according to the
+following logic.
 
 -   Any time you reference a JIRA issue in any part of a commit message,
     git-footnote will look up the issue and append a hyperlink to the
     commit message.
 -   If you write a 1-2 word commit message ("CRM-1234" or "fix
-    CRM-1234"), git-footnote will put the JIRA title in the summary
-    line.\
-
-# Examples
-
-When writing commit messages, these are some examples of good/bad
-patterns to consider. (Note: The first line is displayed in bold because
-it's often the only line displayed when browsing through commits.)\
+    CRM-1234"), git-footnote will put the JIRA issue title in the summary
+    line.
 
 
+## git-footnote examples
 
-Your Commit Message
+Below are some examples of good and bad commit messages, and how git-footnote
+works its magic on them.
 
-Final Commit Message (after running git-footnote)
+!!! note
+    The first line is often the only line displayed when browsing through
+    commits, so pay particular attention to it.
 
-Awesome
 
-**CRM-1234 - Subsystem - Summarize what the commit does**
+### Awesome example
 
-Also write a longer explanation of what the commit does. You don't need
-to give a detailed lesson on how everything works, but it may help to
-describe the corner-case or obscure interaction you were thinking about,
-or it may help to reference other relevant issues (like CRM-4567 or
-CRM-8901). Add whatever seems useful.
+Your Commit Message:
 
-**CRM-1234 - Subsystem - **Summarize** what the commit does**
+```text
+CRM-1234 - Subsystem - Summarize what the commit does
 
-Also write a longer explanation of what the commit does. You don't need
-to give a detailed lesson on how everything works, but it may help to
-describe the corner-case or obscure interaction you were thinking about,
-or it may help to reference other relevant issues (like CRM-4567 or
-CRM-8901). Add whatever seems useful.
+Also write a longer explanation of what the commit does. You don't need to give
+a detailed lesson on how everything works, but it may help to describe the
+corner-case or obscure interaction you were thinking about, or it may help to
+reference other relevant issues (like CRM-4567 or CRM-8901). Add whatever seems
+useful.
+```
 
----\
-  \* CRM-1234: The Issue Title From JIRA\
+Final Commit Message (after running git-footnote):
 
-[http://issues.civicrm.org/jira/browse/CRM-1234](http://issues.civicrm.org/jira/browse/CRM-1234)\
-  \* CRM-4567: The Other Issue Title From JIRA\
+```text
+CRM-1234 - Subsystem - Summarize what the commit does
 
-[http://issues.civicrm.org/jira/browse/CRM-4567](http://issues.civicrm.org/jira/browse/CRM-4567)\
-  \* CRM-8901: The Third Issue Title From JIRA\
+Also write a longer explanation of what the commit does. You don't need to give
+a detailed lesson on how everything works, but it may help to describe the
+corner-case or obscure interaction you were thinking about, or it may help to
+reference other relevant issues (like CRM-4567 or CRM-8901). Add whatever seems
+useful.
 
-[http://issues.civicrm.org/jira/browse/CRM-8901](http://issues.civicrm.org/jira/browse/CRM-8901)
+---
+  * CRM-1234: The Issue Title From JIRA
+    http://issues.civicrm.org/jira/browse/CRM-1234
+  * CRM-4567: The Other Issue Title From JIRA
+    http://issues.civicrm.org/jira/browse/CRM-4567
+  * CRM-8901: The Third Issue Title From JIRA
+    http://issues.civicrm.org/jira/browse/CRM-8901
+```
 
-Great
+### Great example
 
-**CRM-1234 - Subsystem - **Summarize** what the commit does**
+Your Commit Message:
 
-**CRM-1234 - Subsystem - **Summarize** what the commit does**
+```text
+CRM-1234 - Subsystem - Summarize what the commit does
+```
+Final Commit Message (after running git-footnote):
+
+```text
+CRM-1234 - Subsystem - Summarize what the commit does
 
 ---
 
- \* CRM-1234: The Issue Title From JIRA\
+ * CRM-1234: The Issue Title From JIRA
+   http://issues.civicrm.org/jira/browse/CRM-1234
+```
 
-[http://issues.civicrm.org/jira/browse/CRM-1234](http://issues.civicrm.org/jira/browse/CRM-1234)
+### Good example
 
-Good
+Your Commit Message:
 
-**CRM-1234 - **Summarize** what the commit does**
+```text
+CRM-1234 - Summarize what the commit does
+```
 
-**CRM-1234 - **Summarize** what the commit does**
+Final Commit Message (after running git-footnote):
+
+```text
+CRM-1234 - Summarize what the commit does
 
 ---
 
- \* CRM-1234: The Issue Title From JIRA\
+ * CRM-1234: The Issue Title From JIRA
+   http://issues.civicrm.org/jira/browse/CRM-1234
+```
 
-[http://issues.civicrm.org/jira/browse/CRM-1234](http://issues.civicrm.org/jira/browse/CRM-1234)
+### OK example
 
-OK
+Your Commit Message:
 
-**CRM-1234**
+```text
+CRM-1234
+```
 
-**CRM-1234 - The Issue Title From JIRA\
-**
+Final Commit Message (after running git-footnote):
 
-[http://issues.civicrm.org/jira/browse/CRM-1234](http://issues.civicrm.org/jira/browse/CRM-1234)
+```text
+CRM-1234 - The Issue Title From JIRA
+http://issues.civicrm.org/jira/browse/CRM-1234
+```
 
-OK
+### OK example
 
-**fix CRM-1234**
+Your Commit Message:
 
-**fix CRM-1234 - The Issue Title From JIRA**
+```text
+fix CRM-1234
+```
 
-[http://issues.civicrm.org/jira/browse/CRM-1234](http://issues.civicrm.org/jira/browse/CRM-1234) **\
-**
+Final Commit Message (after running git-footnote):
 
-OK
+```text
+fix CRM-1234 - The Issue Title From JIRA
+http://issues.civicrm.org/jira/browse/CRM-1234
+```
 
-**Subsystem - **Summarize** what the commit does**
+### OK example
 
-**Subsystem - Summarize what the commit does**
+Your Commit Message:
 
-So-So
+```text
+Subsystem - Summarize what the commit does
+```
 
-****Summarize** what the commit does**
+*(git-footnote does not change commit message)*
 
-******Summarize**** what the commit does**
+### So-So example
 
-Terrible
+Your Commit Message:
 
-**cleanup**
+```text
+Summarize what the commit does
+```
 
-**cleanup**
+*(git-footnote does not change commit message)*
 
-\
 
-# Hook Installation
+### Terrible example
 
-To take advantage of the automatic formatting on commit messages, you
-must enable CiviCRM's [git
-hooks](http://git-scm.com/book/en/Customizing-Git-Git-Hooks). The
-"gitify" tool (discussed in [Contributing to CiviCRM using
-GitHub](/confluence/display/CRMDOC/Contributing+to+CiviCRM+using+GitHub))
+Your Commit Message:
+
+```text
+cleanup
+```
+
+*(git-footnote does not change commit message)*
+
+
+## Installing git-footnote
+
+Git-footnote works by using
+[git hooks](http://git-scm.com/book/en/Customizing-Git-Git-Hooks).
+
+To take advantage of the automatic formatting on commit messages, you must
+enable CiviCRM's git hooks
+The "gitify" tool (discussed in
+[Contributing to CiviCRM using GitHub](/confluence/display/CRMDOC/Contributing+to+CiviCRM+using+GitHub))
 will create the hooks if you include the "--hooks" option. If you didn't
 originally use "gitify" with the "–hooks" option, then just re-run
 "gitify" and add the "--hooks" option this time. ("gitify" won't replace
-your existing git repos, but it will register hooks on them.)\
+your existing git repos, but it will register hooks on them.)
 
-If you cannot or do not want to use "gitify", then you can [review the
-standard git hooks included with
-CiviCRM](https://github.com/civicrm/civicrm-core/tree/master/tools/scripts/git)
+If you cannot or do not want to use "gitify", then you can
+[review the standard git hooks included with CiviCRM](https://github.com/civicrm/civicrm-core/tree/master/tools/scripts/git)
 and write your own. Be sure to look at each of your git repositories
 ("civicrm-core", "civicrm-drupal", etc) to ensure the hooks are
-registered.\
+registered.
 
-# FAQ
+## FAQ
 
 -   **Q: What if I write something that doesn't have a JIRA issue?**
 -   A: It's generally good practice to create a JIRA issue before
     working on a problem, then reference the issue in the commit
     message. However, if that seems inappropriate, then make reference
     to the general **area or subsystem** instead.
--   **Q: What is an "area" or "subsystem"?**\
-
--   The term is purposefully ambiguous - it's difficult to think of a
+-   **Q: What is an "area" or "subsystem"?**
+-   A: The term is purposefully ambiguous - it's difficult to think of a
     hard rule, and it seems to depend on how many lines/files/functions
     were touched. It might be the name of a class, a function, a
     template, a directory, or a component. The goal is the provide some
     clue to the future reader so that she can guess which commits would
     be relevant to the bug/issue she's investigating. However, here are
-    some examples of commit-messages that mention the area/subsystem:\
-    -   "CRM\_Core\_Error - Cleanup log format"
-    -   "api/v3/Email - Remove unused variable"
-    -   "api/v3 - Fix various comment blocks"
-    -   "civicrm/contact/view - fix 5.4 static errors"
+    some examples of commit-messages that mention the area/subsystem:
+    -   `CRM_Core_Error - Cleanup log format`
+    -   `apiv3Email - Remove unused variable`
+    -   `apiv3 - Fix various comment blocks`
+    -   `civicrm/contact/view - fix 5.4 static errors`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,8 @@ pages:
 - Core code:
   - Hacking the core: core/hacking.md
   - Architecture: core/architecture.md
+- Best practices:
+  - Commit messages: best-practices/commit-messages.md
 - Miscellaneous:
    - Extension Lifecycle: extend-stages.md
    - Markdown: markdownrules.md

--- a/redirects/wiki-crmdoc.txt
+++ b/redirects/wiki-crmdoc.txt
@@ -2,3 +2,4 @@ Documentation+Infrastructure+Canary develop
 The+developer+community basics/community
 Create+an+Extension extensions/basics
 The+codebase core/architecture
+Git+Commit+Messages+for+CiviCRM best-practices/commit-messages


### PR DESCRIPTION
A simple migration of the Git Commit Messages wiki page
https://wiki.civicrm.org/confluence/display/CRMDOC/Git+Commit+Messages+for+CiviCRM