### PR TITLE
Various spelling, grammar, and clarity of meaning improvements.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,10 +15,10 @@ poked, prodded, twisted, and hacked. It can be customized, extended, and
 collaboratively developed. This documentation tells you how to do that.
 
 It starts with a high level introduction to get you familiar
-with CiviCRM development. It covers setting up your developer environment,
-ensuring that you really need to start coding (i.e. you can't achieve what you
-want thought configuration or installing an already existing extension), best
-practice ways to extend CiviCRM (aka how to write an extensions), things you
+with CiviCRM development. It covers setting up your development environment,
+checking whether or not you actually need to implement your own custom code (i.e. you can't achieve what you
+want through configuration or installing an already existing extension), best
+practice ways to extend CiviCRM (a.k.a. how to write an extension), things you
 should know before you start hacking on core, and best practice for testing.
 
 The guide also includes detailed references for tools and subsystems


### PR DESCRIPTION
Corrected the incorrectly used word 'thought' to 'through'. 
Corrected grammar of 'how to write an extensions'. 
Clarified the meaning of 'ensuring that you really need to start coding'.
Added full stops to 'aka' abbreviation to make it clearer it is an abbreviation.
Changed 'developer environment' to more conventional and accurate phrase 'development environment'.