### PR TITLE
mkdocs.yml - Rearrange top level of TOC

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,11 +74,6 @@ pages:
   # CiviMail: /reference/civimail.md            # page-tree = NEED_NEW_PAGE
   # CiviReport: /reference/civireport.md        # page-tree = NEED_NEW_PAGE
   # Payment Processing: /reference/payment.md   # page-tree = NEED_NEW_PAGE
-- Content to reorganize:
-  - Extensions files: extensions/files.md
-  - Requirements: requirements.md
-  - Develop: develop.md
-  - hookref-old: hookref-old.md
 - Hooks:
   - Using hooks: hooks.md                        # page-tree = NEED_PAGE_MOVE to /hooks/usage.md
   - Batch hooks:
@@ -198,3 +193,8 @@ pages:
   - CiviRules hooks:
     - hook_civirules_alter_trigger_data: hooks/hook_civirules_alter_trigger_data.md
     - hook_civirules_logger: hooks/hook_civirules_logger.md
+- Content to reorganize:
+  - Extensions files: extensions/files.md
+  - Requirements: requirements.md
+  - Develop: develop.md
+  - hookref-old: hookref-old.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,13 +19,12 @@ pages:
   - Developer Community: basics/community.md    # page-tree = DONE
   - Useful Skills: basics/skills.md       # page-tree = DONE
   - Planning Your Project: basics/planning.md   # page-tree = DONE
+  # buildkit: /setup/buildkit.md                # page-tree = NEED_NEW_PAGE  # summary: See Github README for download instructions. Alternatively, follow links and install particular tools as-needed.
+  - Debugging: dev-tools/debugging.md           # page-tree = NEED_PAGE_MOVE to /setup/debugging.md
 - Documentation:
   - Writing Documentation: documentation.md     # page-tree = NEED_PAGE_MOVE to /documentation/writing.md
   - Markdown: markdownrules.md                  # page-tree = NEED_PAGE_MOVE to /documentation/markdown.md
   - Style Guide: best-practices/documentation-style-guide.md  # page-tree = NEED_PAGE_MOVE to /documentation/style-guide.md
-- Setup:
-  # buildkit: /setup/buildkit.md                # page-tree = NEED_NEW_PAGE  # summary: See Github README for download instructions. Alternatively, follow links and install particular tools as-needed.
-  - Debugging: dev-tools/debugging.md           # page-tree = NEED_PAGE_MOVE to /setup/debugging.md
 - Core Development:
   - When to edit core: core/hacking.md             # page-tree = NEED_PAGE_MOVE to /core/deciding.md
   # How to Contribute: /core/contributing.md    # page-tree = NEED_NEW_PAGE # summary: General summary of process (git+issues+PRs+Mattermost)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,14 +33,6 @@ pages:
   # Submitting a Patch: /core/patches.md        # page-tree = NEED_NEW_PAGE
   # Review Process: /core/review.md             # page-tree = NEED_NEW_PAGE  # summary: Detailed guidance on how to review PRs
   # Verifying a Bug Fix: /core/verifying.md     # page-tree = NEED_NEW_PAGE
-- API:
-  - API Intro: api/general.md                   # page-tree = DONE
-  - API Usage: api/usage.md                     # page-tree = DONE
-  - API Actions: api/actions.md                 # page-tree = DONE
-  - API Parameters: api/params.md               # page-tree = DONE
-  # API Permissions: api/permissions.md         # page-tree = NEED_NEW_PAGE
-  - API Chaining: api/chaining.md
-  # API Changes: api/changes.md                 # page-tree = NEED_NEW_PAGE
 - Extensions Development:
   - Basics: extensions/basics.md                   # page-tree = DONE
   - civix: extensions/civix.md                     # page-tree = DONE
@@ -74,6 +66,14 @@ pages:
   # CiviMail: /reference/civimail.md            # page-tree = NEED_NEW_PAGE
   # CiviReport: /reference/civireport.md        # page-tree = NEED_NEW_PAGE
   # Payment Processing: /reference/payment.md   # page-tree = NEED_NEW_PAGE
+- API:
+  - API Intro: api/general.md                   # page-tree = DONE
+  - API Usage: api/usage.md                     # page-tree = DONE
+  - API Actions: api/actions.md                 # page-tree = DONE
+  - API Parameters: api/params.md               # page-tree = DONE
+  # API Permissions: api/permissions.md         # page-tree = NEED_NEW_PAGE
+  - API Chaining: api/chaining.md
+  # API Changes: api/changes.md                 # page-tree = NEED_NEW_PAGE
 - Hooks:
   - Using hooks: hooks.md                        # page-tree = NEED_PAGE_MOVE to /hooks/usage.md
   - Batch hooks:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,10 +21,6 @@ pages:
   - Planning Your Project: basics/planning.md   # page-tree = DONE
   # buildkit: /setup/buildkit.md                # page-tree = NEED_NEW_PAGE  # summary: See Github README for download instructions. Alternatively, follow links and install particular tools as-needed.
   - Debugging: dev-tools/debugging.md           # page-tree = NEED_PAGE_MOVE to /setup/debugging.md
-- Documentation:
-  - Writing Documentation: documentation.md     # page-tree = NEED_PAGE_MOVE to /documentation/writing.md
-  - Markdown: markdownrules.md                  # page-tree = NEED_PAGE_MOVE to /documentation/markdown.md
-  - Style Guide: best-practices/documentation-style-guide.md  # page-tree = NEED_PAGE_MOVE to /documentation/style-guide.md
 - Core Development:
   - When to edit core: core/hacking.md             # page-tree = NEED_PAGE_MOVE to /core/deciding.md
   # How to Contribute: /core/contributing.md    # page-tree = NEED_NEW_PAGE # summary: General summary of process (git+issues+PRs+Mattermost)
@@ -193,6 +189,10 @@ pages:
   - CiviRules hooks:
     - hook_civirules_alter_trigger_data: hooks/hook_civirules_alter_trigger_data.md
     - hook_civirules_logger: hooks/hook_civirules_logger.md
+- Documentation:
+  - Writing Documentation: documentation.md     # page-tree = NEED_PAGE_MOVE to /documentation/writing.md
+  - Markdown: markdownrules.md                  # page-tree = NEED_PAGE_MOVE to /documentation/markdown.md
+  - Style Guide: best-practices/documentation-style-guide.md  # page-tree = NEED_PAGE_MOVE to /documentation/style-guide.md
 - Content to reorganize:
   - Extensions files: extensions/files.md
   - Requirements: requirements.md


### PR DESCRIPTION
This puts in the following order:

 * Basics
 * Core Development
 * Extensions Development
 * API
 * Hooks
 * Documentation
 * Content to reorganize

Rationales:

 * "Core/Extension" is a dichotomy. They belong next to each other.
 * "API/Hooks" is a dichotomy. They belong next to each other.
 * Aside: I don't care much if "Core/Extension" goes before or after "API/Hooks"
 * "Documentation" is meta. A new dev should generally learn about dev before they start writing dev docs. ;)

If I had my druthers, we could include some kind of horizontal bar, e.g.

 * Basics
 * --
 * Core
 * Extensions
 * --
 * API
 * Hooks
 * Documentation
 * --
 * Content to reorganize