### PR TITLE
Add script to locally serve MkDocs site through docker

### DIFF
--- a/docker-mkdocs-serve
+++ b/docker-mkdocs-serve
@@ -1,1 +1,0 @@
-docker run --rm -v "$PWD":/docs -p 8000:8000 -w /docs seanmadsen/civicrm-mkdocs serve --dirtyreload -a 0.0.0.0:8000

--- a/docker-mkdocs-serve
+++ b/docker-mkdocs-serve
@@ -1,0 +1,1 @@
+docker run --rm -v "$PWD":/docs -p 8000:8000 -w /docs seanmadsen/civicrm-mkdocs serve --dirtyreload -a 0.0.0.0:8000

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -71,7 +71,7 @@ The most advanced way to work on a book is to use git to download all the markdo
 1. *(optional)* If you have [Docker](https://www.docker.com/) installed, then at this point you can run the following command and then skip to the "view the book" step below.
 
     ```
-    docker run --rm -v "$PWD":/docs -p 8000:8000 -w /docs seanmadsen/civicrm-mkdocs serve --dirtyreload -a 0.0.0.0:8000
+    docker run --rm -v "$PWD":/docs -p 8000:8000 -w /docs seanmadsen/civicrm-docker-mkdocs serve --dirtyreload -a 0.0.0.0:8000
     ```
 
 1. Install [pip](https://pypi.python.org/pypi/pip) (python package manager)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -68,7 +68,11 @@ The most advanced way to work on a book is to use git to download all the markdo
         cd civicrm-dev-docs
         ```
         
-1. *(optional)* If you have [Docker](https://www.docker.com/) installed, then at this point you can run the script `./docker-mkdocs-serve` and skip to the "view the book" step below.
+1. *(optional)* If you have [Docker](https://www.docker.com/) installed, then at this point you can run the following command and then skip to the "view the book" step below.
+
+    ```
+    docker run --rm -v "$PWD":/docs -p 8000:8000 -w /docs seanmadsen/civicrm-mkdocs serve --dirtyreload -a 0.0.0.0:8000
+    ```
 
 1. Install [pip](https://pypi.python.org/pypi/pip) (python package manager)
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -29,7 +29,7 @@ In rarer cases, if you have an edit that pertains to a specific version, (e.g. d
 
 ### Languages
 
-A book can have multiple languages, and we use separate repositories for different languages. For example, you can click *See all X editions* and find the repositories for additional languages.  
+A book can have multiple languages, and we use separate repositories for different languages. For example, you can click *See all X editions* and find the repositories for additional languages.
 
 ## Contributing to documentation
 
@@ -52,11 +52,23 @@ The simplest way to help out is to *describe* a change that you think *should* b
 
 ### Editing through GitHub
 
-Please see the documentation for editing with Git in the [CiviCRM user guide](https://docs.civicrm.org/user/en/stable/the-civicrm-community/contributing-to-this-manual/#single_changes).   
+Please see the documentation for editing with Git in the [CiviCRM user guide](https://docs.civicrm.org/user/en/stable/the-civicrm-community/contributing-to-this-manual/#single_changes).
 
 ### Testing locally with MkDocs {:#mkdocs}
 
 The most advanced way to work on a book is to use git to download all the markdown files to your computer, edit them locally, preview the changes with [MkDocs](http://mkdocs.org/), then use git to push those changes to your personal fork, and finally make a "pull request" on the main repository. This approach makes editing very fast and easy, but does require a bit of setup, and some knowledge of how git works.
+
+1.  Obtain the source files for the book you want to edit
+    1.  Find the repository on GitHub *(see "repository" links above, or the "GitHub" link on the bottom left of screen of the documentation you are reading)*
+    1.  Fork the repository on GitHub.
+    1.  Clone *your fork* of the repository to your computer
+				
+        ```bash
+        git clone https://github.com/YourGitHubUserName/civicrm-dev-docs.git
+        cd civicrm-dev-docs
+        ```
+        
+1. *(optional)* If you have [Docker](https://www.docker.com/) installed, then at this point you can run the script `./docker-mkdocs-serve` and skip to the "view the book" step below.
 
 1. Install [pip](https://pypi.python.org/pypi/pip) (python package manager)
 
@@ -69,17 +81,7 @@ The most advanced way to work on a book is to use git to download all the markdo
     sudo pip install mkdocs mkdocs-material pygments pymdown-extensions
     ```
 
-1.  Obtain the source files for the book you want to edit
-    1.  Find the repository on GitHub *(see "repository" links above, or the "GitHub" link on the bottom left of screen of the documentation you are reading)*
-    1.  Fork the repository on GitHub.
-    1.  Clone *your fork* of the repository to your computer
-				
-        ```bash
-        git clone https://github.com/YourGitHubUserName/civicrm-dev-docs.git
-        cd civicrm-dev-docs
-        ```
-
-1. Launch a local copy of the book
+1. Serve a local copy of the book with MkDocs
     1. Run:
 
         ```bash
@@ -89,7 +91,7 @@ The most advanced way to work on a book is to use git to download all the markdo
         -   If you get `[Errno 98] Address already in use` then try using a
             different port with `mkdocs serve -a localhost:8001`
 
-    1. View through your browser at `http://localhost:8000`.
+1. View the book locally your browser at `http://localhost:8000`.
 
 1.  Edit the [markdown](/markdownrules.md) with an editor of your choice. As you
     save your changes `mkdocs` will automatically reprocess the page and


### PR DESCRIPTION
This is a first stab at using Docker to make it easier for people to preview the Dev Guide locally. I'd like some feedback from others about the idea of including this script in this repo (and potentially other repos like the User Guide). @mickadoo @PalanteJon @ErichBSchulz (Docker fans I know) do any of you have thoughts on this? The idea here is that if someone has git and Docker installed locally then they can run this new script `./docker-mkdocs-serve` to preview the book locally and then edit (without needing to install pip, mkdocs, etc). 

Concerns/questions: 

* Would this script even be useful to anyone? Maybe not. If they can install git and Docker it's only a small leap to install the other packages. OTOH, I've seen a *lot* of people have challenges getting MkDocs working locally. *Maybe* there would be *some* people who benefit from using this script?
* Is my approach a good one? I'm new to Docker. The goal here is to use Docker to make it easier for people to run `mkdocs serve`, but am I really using Docker the *right way* here? Not sure about that. Note that there's no Dockerfile here. My approach is to use a [custom public image](https://hub.docker.com/r/seanmadsen/civicrm-mkdocs/) hosted on Docker Hub which I built to have MkDocs and other dependencies that our docs books require.