### PR TITLE
Remove scary warning

### DIFF
--- a/docs/hooks/hook_civicrm_permission.md
+++ b/docs/hooks/hook_civicrm_permission.md
@@ -7,9 +7,7 @@ This hook is called to allow custom permissions to be defined.
 ## Notes
 
 Available starting in 4.3, with permission descriptions supported
-starting in 4.6.  Version 4.6.0 [may cause
-trouble](https://issues.civicrm.org/jira/browse/CRM-16230), even without
-descriptions.
+starting in 4.6.
 
 ## Definition
 


### PR DESCRIPTION
Removed scary warning that only applies to a single point release.