### PR TITLE
Fixed misnamed hook

### DIFF
--- a/docs/hooks/hook_civicrm_triggerInfo.md
+++ b/docs/hooks/hook_civicrm_triggerInfo.md
@@ -1,4 +1,4 @@
-# hook_civicrm_trigger_info
+# hook_civicrm_triggerInfo
 
 ## Summary
 

--- a/docs/hooks/list.md
+++ b/docs/hooks/list.md
@@ -32,7 +32,7 @@ This is an overview list of all available hooks, listed by category.
 * **[hook_civicrm_post](/hooks/hook_civicrm_post.md)** - called after a db write on some core objects.
 * **[hook_civicrm_postSave_table_name](/hooks/hook_civicrm_postSave_table_name.md)** - called after writing to a database table that has an associated DAO, including core tables but not custom tables or log tables.
 * **[hook_civicrm_pre](/hooks/hook_civicrm_pre.md)** - called before a db write on some core objects.
-* **[hook_civicrm_trigger_info](/hooks/hook_civicrm_trigger_info.md)** - allows you to define MySQL triggers.
+* **[hook_civicrm_triggerInfo](/hooks/hook_civicrm_triggerInfo.md)** - allows you to define MySQL triggers.
 * **[hook_civicrm_referenceCounts](/hooks/hook_civicrm_referenceCounts.md)** - called to determine the reference-count for a record.
 
 ## Entity hooks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,7 +107,7 @@ pages:
     - hook_civicrm_post: hooks/hook_civicrm_post.md
     - hook_civicrm_postSave_table_name: hooks/hook_civicrm_postSave_table_name.md
     - hook_civicrm_pre: hooks/hook_civicrm_pre.md
-    - hook_civicrm_trigger_info: hooks/hook_civicrm_trigger_info.md
+    - hook_civicrm_triggerInfo: hooks/hook_civicrm_triggerInfo.md
     - hook_civicrm_referenceCounts: hooks/hook_civicrm_referenceCounts.md
   - Entity hooks:
     - hook_civicrm_entityTypes: hooks/hook_civicrm_entityTypes.md

--- a/redirects/internal.txt
+++ b/redirects/internal.txt
@@ -4,3 +4,4 @@ markdownrules documentation/markdown
 best-practices/documentation-style-guide documentation/style-guide
 extensions/basics extensions
 api/general api
+hooks/hook_civicrm_trigger_info hooks/hook_civicrm_triggerInfo


### PR DESCRIPTION
Note this change renames the file as well. A redirect is probably needed to preserve old links, but I'm not sure how this is managed.