### PR TITLE
debugging.md - Remove misleading link

### DIFF
--- a/docs/tools/debugging.md
+++ b/docs/tools/debugging.md
@@ -196,10 +196,11 @@ Then, be sure to add the parameter `angularDebug=1` to the URL.
 
 Clearing the cache is not a debugging technique, specifically. But sometimes it helps, and so is mentioned here for the sake of completeness.
 
-Using a web browser, either:
+Using a web browser:
 
 -   Navigate directly to `civicrm/clearcache`
--   Navigate to "Administer => System Settings => Cleanup Caches"
+
+<!-- FIXME: This page is misleading:  Navigate to "Administer => System Settings => Cleanup Caches" -->
 
 Using the command line, you can clear all caches with one of these commands:
 
@@ -209,8 +210,8 @@ Using the command line, you can clear all caches with one of these commands:
 Alternatively, you can call the following methods in PHP code:
 
 -   `civicrm_api3('System', 'flush', array());` clears many different caches
--   `CRM_Core_Config::clearDBCache();` clears the database cache
--   `CRM_Core_Config::cleanup();` clears the file cache
+-   `CRM_Core_Config::clearDBCache();` clears *only* the database cache
+-   `CRM_Core_Config::cleanup();` clears *only* the file cache
 
 
 


### PR DESCRIPTION
The doc mentions the page "Administer => System Settings => Cleanup Caches and Update Paths" as a way to clear caches. This is half-true: it does clear `templates_c` and the `civicrm_cache` table, but there are other things that it doesn't touch. (Compare `CRM_Admin_form_Setting_UpdateConfigBackend::postProcess` with the `CRM_Core_Invoke::rebuildMenuAndCaches`.)

IMHO, `UpdateConfigBackend::postProcess` should be patched to just do a general system flush (`civicrm_api3('System', 'flush', array())`) -- but (for now) the page is misleading and we shouldn't direct people there.