### PR TITLE
CRM-20926 - hook_civicrm_{alter,xml}Menu - Fill in docs. Add PHPIDS docs.

### DIFF
--- a/docs/hooks/hook_civicrm_alterMenu.md
+++ b/docs/hooks/hook_civicrm_alterMenu.md
@@ -4,10 +4,6 @@
 
 This hook is called when building CiviCRM's list of HTTP routes and should be used when you want to register custom paths or URLS.
 
-## Notes
-
-You will need to visit `/civicrm/menu/rebuild?reset=1` to pick up your additions.
-
 !!! note "Comparison of Related Hooks"
     This is one of three related hooks. The hooks:
 
@@ -15,6 +11,9 @@ You will need to visit `/civicrm/menu/rebuild?reset=1` to pick up your additions
     -   [hook_civicrm_alterMenu](/hooks/hook_civicrm_alterMenu.md) manipulates the list of HTTP routes (using PHP arrays)
     -   [hook_civicrm_xmlMenu](/hooks/hook_civicrm_xmlMenu.md) manipulates the list of HTTP routes (using XML files)
 
+!!! tip "Applying changes"
+
+    Menu data is cached. After making a change to the menu data, [clear the system cache](/tools/debugging.md#clearing-the-cache).
 
 ## Availability
 

--- a/docs/hooks/hook_civicrm_alterMenu.md
+++ b/docs/hooks/hook_civicrm_alterMenu.md
@@ -34,6 +34,10 @@ Added in CiviCRM 4.7.11.
     -   "*access_callback*": (usually omitted)
     -   "*access_arguments*": Description of required permissions. Ex:
         *array(array('access CiviCRM'), 'and')*
+    -   "*ids_arguments*": This array defines any [page-specific PHPIDS exceptions](/hooks/hook_civicrm_xmlMenu.md#xml-ids). It includes any of these three child elements:
+        - "*json*": Array of input fields which may contain JSON data.
+        - "*html*": Array of input fields which may contain HTML data.
+        - "*exception*": Array of input fields which are completely exempted from PHPIDS.
 
 ## Returns
 

--- a/docs/hooks/hook_civicrm_alterMenu.md
+++ b/docs/hooks/hook_civicrm_alterMenu.md
@@ -39,7 +39,7 @@ Added in CiviCRM 4.7.11.
     -   "*ids_arguments*": This array defines any [page-specific PHPIDS exceptions](/hooks/hook_civicrm_xmlMenu.md#xml-ids). It includes any of these three child elements:
         - "*json*": Array of input fields which may contain JSON data.
         - "*html*": Array of input fields which may contain HTML data.
-        - "*exception*": Array of input fields which are completely exempted from PHPIDS.
+        - "*exceptions*": Array of input fields which are completely exempted from PHPIDS.
 
 ## Returns
 

--- a/docs/hooks/hook_civicrm_alterMenu.md
+++ b/docs/hooks/hook_civicrm_alterMenu.md
@@ -4,6 +4,8 @@
 
 This hook is called when building CiviCRM's list of HTTP routes and should be used when you want to register custom paths or URLS.
 
+## Notes
+
 !!! note "Comparison of Related Hooks"
     This is one of three related hooks. The hooks:
 

--- a/docs/hooks/hook_civicrm_xmlMenu.md
+++ b/docs/hooks/hook_civicrm_xmlMenu.md
@@ -5,6 +5,8 @@
 This hook is called when building CiviCRM's menu structure, which is
 used to render urls in CiviCRM.
 
+## Notes
+
 !!! note "Comparison of Related Hooks"
     This is one of three related hooks. The hooks:
 

--- a/docs/hooks/hook_civicrm_xmlMenu.md
+++ b/docs/hooks/hook_civicrm_xmlMenu.md
@@ -81,3 +81,45 @@ The administration screen (`civicrm/admin`) includes a generated list of fields.
  * `<icon>`
  * `<adminGroup>`
  * `<weight>`
+
+## XML: IDS
+
+[PHPIDS](https://github.com/PHPIDS/PHPIDS) provides an extra layer of
+security to mitigate the risk of cross-site scripting vulnerabilities, SQL
+injection vulnerabilities, and so on.  In CiviCRM, PHPIDS scans all inputs
+for suspicious data (such as complex Javascriptor SQL code) before allowing
+the page-controller to execute.
+
+However, in some rare occasions, it is expected that the page-controller
+will accept otherwise suspicious data -- for example, a REST endpoint may
+accept JSON which superfically resembles complex XSS Javascript code; or an
+administrative form may allow admins to customize the HTML of a screen.
+When processing these page-requests, PHPIDS may generate false alarms.
+
+In the following example, we provide hints to PHPIDS indicating that the
+page `civicrm/my-form` accepts some inputs (`field_1`, `field_2`, `field_3`,
+and `field_4`) which may ordinarily look suspicious.
+
+```xml
+<?xml version="1.0" encoding="iso-8859-1" ?>
+<menu>
+  <item>
+    <path>civicrm/my-form</path>
+    ...
+    <ids_arguments>
+      <!-- Fields #1 and #2 accept JSON input. These are partially exempt from PHPIDS -- they use less aggressive heuristics. -->
+      <json>field_1</json>
+      <json>field_2</json>
+      <!-- Field #3 accepts HTML input. It is  partially exempt from PHPIDS -- they use less aggressive heuristics. -->
+      <html>field_3</html>
+      <!-- Field #4 accepts anything; it is not protected by PHPIDS heuristics. -->
+      <exception>field_4</exception>
+    </ids_arguments>
+  </item>
+</menu>
+```
+
+!!! tip "Tip: Narrow exceptions are better than blanket exceptions"
+    The `<ids_arguments>` element allows you to define a narrow exception for a specific field on a specific page.
+    [hook_civicrm_idsException](/hooks/hook_civicrm_idsException.md) supports a blanket exemption for the entire page.
+    When possible, it is better to use a narrow exception.

--- a/docs/hooks/hook_civicrm_xmlMenu.md
+++ b/docs/hooks/hook_civicrm_xmlMenu.md
@@ -5,12 +5,6 @@
 This hook is called when building CiviCRM's menu structure, which is
 used to render urls in CiviCRM.
 
-## Notes
-
-This hook should be used when you want
-to register your custom module url's in CiviCRM. You will need to visit
-`/civicrm/menu/rebuild?reset=1` to pick up your additions.
-
 !!! note "Comparison of Related Hooks"
     This is one of three related hooks. The hooks:
 
@@ -18,7 +12,9 @@ to register your custom module url's in CiviCRM. You will need to visit
     -   [hook_civicrm_alterMenu](/hooks/hook_civicrm_alterMenu.md) manipulates the list of HTTP routes (using PHP arrays)
     -   [hook_civicrm_xmlMenu](/hooks/hook_civicrm_xmlMenu.md) manipulates the list of HTTP routes (using XML files)
 
+!!! tip "Applying changes"
 
+    Menu data is cached. After making a change to the menu data, [clear the system cache](/tools/debugging.md#clearing-the-cache).
 
 ## Definition
 


### PR DESCRIPTION
This fills in some missing documentation for the menu hooks, and it adds new documentation for the
`ids_arguments` defined by CRM-20926.

Testing tips: 
 * If you'd like test a particular form, you can try opening your form in a browser and
   passing a suspicious input (as in https://gist.github.com/totten/27cc1bde206fe17371c8a6d7cb361e49).
 * If you'd like to inspect the exact ratings produced by PHPIDS for the inputs, see
   the throw-away script `check-ids-value.php` (also in https://gist.github.com/totten/27cc1bde206fe17371c8a6d7cb361e49).