### PR TITLE
Add security note about AngularJS in Smarty

### DIFF
--- a/docs/framework/angular/loader.md
+++ b/docs/framework/angular/loader.md
@@ -160,6 +160,24 @@ in the Smarty template:
 </div>
 ```
 
+!!! caution "Security note"
+
+    The [AngularJS Security Guide](https://docs.angularjs.org/guide/security) says:
+    
+    > Do not use user input to generate templates dynamically
+    
+    This means that if you put an `ng-app` element in a Smarty template as shown above, it's very important that you do not use Smarty to put any user input inside the `ng-app` element.
+    
+    For example, the following Smarty template would be a security risk:
+    
+    ```html
+    <div ng-app="crmCaseType">
+      <div ng-view="">{$untrustedData}</div>
+    </div>
+    ```
+    
+    because if the `$untrustedData` PHP variable contains a string like `{{1+2}}`, then AngularJS will execute `1+2` and open the door to XSS vulnerabilities. 
+
 Finally, flush the cache and visit the new page.
 
 ```


### PR DESCRIPTION
I think this PR is pretty straightforward. Will merge in 5 days if no one provides feedback. 

@seamuslee001 you might be interested in this. I was thinking that potentially we could have an "AngularJS" section within your security page, perhaps just with this content in it. If you think that's a good idea, then we could move this content over when you make your page, and link to it from where I've added it now.