### PR TITLE
Migrate "Extension Reference" wiki page

### DIFF
--- a/docs/extensions/extension-reference.md
+++ b/docs/extensions/extension-reference.md
@@ -22,18 +22,6 @@ extensions, see [Create an Extension](/extensions/index.md).
 | 3.3 | Introduce extension-types for payment-processors, report-templates, and custom-searches.
 
 
-## Packaging
-
-For redistribution, an extension must be packaged as a .zip file which
-meets these requirements:
-
--   All content in the .zip must be stored under a single folder. The
-    folder should match the extension's unique key. (In 4.1 and earlier,
-    the matched name was mandatory. In 4.2 and later, the matched name
-    is optional.)
--   The folder must include a file named `info.xml` which meets the
-    specification below.
-
 ## Tags in info.xml
 
 

--- a/docs/extensions/extension-reference.md
+++ b/docs/extensions/extension-reference.md
@@ -235,17 +235,6 @@ extensions, see [Create an Extension](/extensions/index.md).
 +--------------------------+--------------------------+--------------------------+
 
 
-## Choose unique key for your extension
-
-Every extension has unique name called an **extension key**. It's built
-using Java-like reverse domain naming to make it easier to identify
-unique extensions.
-
-Extension key examples
-
-* If your website is `circleinteractive.co.uk`, and you've developed a payment processor plugin for Sagepay, your extension key might be: `uk.co.circleinteractive.payment.sagepay`
-* If your website is `civiconsulting.com`, and you're developing a custom search for event registration, your extension key might be: `com.civiconsulting.search.eventregistration`.
-
 ## Custom search specific typeInfo fields
 
 Custom search extensions do not require typeInfo section in the info.xml

--- a/docs/extensions/extension-reference.md
+++ b/docs/extensions/extension-reference.md
@@ -1,0 +1,415 @@
+# Extension Reference
+
+<div class="panel"
+style="background-color: #FFFFCE;border-color: #000;border-style: solid;border-width: 1px;">
+
+<div class="panelHeader"
+style="border-bottom-width: 1px;border-bottom-style: solid;border-bottom-color: #000;background-color: #F7D6C1;">
+
+**Table of Contents**
+
+</div>
+
+<div class="panelContent" style="background-color: #FFFFCE;">
+
+<div>
+
+-   [Introduction](#ExtensionReference-Introduction)
+-   [Changelog](#ExtensionReference-Changelog)
+-   [Packaging](#ExtensionReference-Packaging)
+-   [Tags in info.xml](#ExtensionReference-Tagsininfo.xml)
+
+<!-- -->
+
+-   [Choose unique key for your
+    extension](#ExtensionReference-Chooseuniquekeyforyourextension)
+-   [Custom search specific typeInfo
+    fields](#ExtensionReference-CustomsearchspecifictypeInfofields)
+-   [Report template specific typeInfo
+    fields](#ExtensionReference-ReporttemplatespecifictypeInfofields)
+-   [Payment processor specific typeInfo
+    fields](#ExtensionReference-PaymentprocessorspecifictypeInfofields)
+
+<!-- -->
+
+-   [Example XML - type =
+    Module](#ExtensionReference-ExampleXML-type=Module)
+
+</div>
+
+</div>
+
+</div>
+
+# Introduction
+
+A ***native CiviCRM extension*** is a feature provided by a third-party
+developer which can be installed on CiviCRM. To support automated
+distribution and installation, an extension must be packaged according
+to a particular specification. This page documents the technical
+structure of an extension. For a proper introduction to developing
+extensions, see [Create an
+Extension](/confluence/display/CRMDOC/Create+an+Extension).
+
+# Changelog
+
+<div class="table-wrap">
+
+  CiviCRM Version   Description
+  ----------------- ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  4.5               &lt;develStage&gt; is not always required; when using civicrm.org's automated release management, this value is inferred from the version; for manual or private releases, the field should still be defined.
+  4.2               Most extensions should be packaged as generic *module* rather than type-specific extensions.
+  4.2               &lt;downloadUrl&gt; is optional for ordinary development; when using civicrm.org to distribute extensions, the &lt;downloadUrl&gt; will be specified when announcing the release on the website
+  4.2               &lt;downloadUrl&gt; can point to auto-generated zipballs on Github.com
+  4.2               Introduce stable support for generic modules.
+  4.1               Introduce experimental extension-type for generic modules*.*
+  3.3               Introduce extension-types for payment-processors, report-templates, and custom-searches.
+
+</div>
+
+# Packaging
+
+For redistribution, an extension must be packaged as a .zip file which
+meets these requirements:
+
+-   All content in the .zip must be stored under a single folder. The
+    folder should match the extension's unique key. (In 4.1 and earlier,
+    the matched name was mandatory. In 4.2 and later, the matched name
+    is optional.)
+-   The folder must include a file named "info.xml" which meets the
+    specification below.
+
+# Tags in info.xml
+
+<div class="table-wrap">
+
++--------------------------+--------------------------+--------------------------+
+| element name             | description              | required?                |
++==========================+==========================+==========================+
+| **extension**            | enclosing element for    | **YES**                  |
+|                          | all the information in   |                          |
+|                          | info.xml - everything    |                          |
+|                          | needs to sit inside of   |                          |
+|                          | it. Attributes are:      |                          |
+|                          |                          |                          |
+|                          | 1.  **key**: unique name |                          |
+|                          |     of the extension     |                          |
+|                          |     (should match the    |                          |
+|                          |     name of directory    |                          |
+|                          |     this extension       |                          |
+|                          |     resides in). See     |                          |
+|                          |     information on       |                          |
+|                          |     choosing the         |                          |
+|                          |     extension key below  |                          |
+|                          |     for                  |                          |
+|                          |     more information.    |                          |
+|                          | 2.  **type**: one of     |                          |
+|                          |     "module", "search",  |                          |
+|                          |     "payment", "report", |                          |
+|                          |     meaning that this    |                          |
+|                          |     extension is -       |                          |
+|                          |     respectively - a     |                          |
+|                          |     custom module,       |                          |
+|                          |     search, payment      |                          |
+|                          |     processor or         |                          |
+|                          |     custom report.       |                          |
++--------------------------+--------------------------+--------------------------+
+| **downloadUrl**          | the url to the zip file  | **NO\                    |
+|                          | with your extension.     | **                       |
+|                          |                          |                          |
+|                          | *NOTE: Prior to CiviCRM  |                          |
+|                          | 4.2, the downloadUrl was |                          |
+|                          | mandatory in info.xml.   |                          |
+|                          | It needed to point to a  |                          |
+|                          | plain .zip file whose    |                          |
+|                          | content included a base  |                          |
+|                          | folder; and it was       |                          |
+|                          | mandatory for the base   |                          |
+|                          | folder to be named after |                          |
+|                          | the extension.\          |                          |
+|                          | *                        |                          |
+|                          |                          |                          |
+|                          | *NOTE: Beginning with    |                          |
+|                          | CiviCRM 4.2, developers  |                          |
+|                          | should not normally      |                          |
+|                          | include the downloadUrl. |                          |
+|                          | The information will     |                          |
+|                          | only be required when    |                          |
+|                          | submitting a new release |                          |
+|                          | on civicrm.org.\         |                          |
+|                          | *                        |                          |
++--------------------------+--------------------------+--------------------------+
+| **file**                 | the name of the file to  | **YES**                  |
+|                          | invoke when extension is |                          |
+|                          | executed (not including  |                          |
+|                          | .php file extension).    |                          |
+|                          | This file must be        |                          |
+|                          | present in the root of   |                          |
+|                          | the extension .zip file  |                          |
+|                          | / in base directory of   |                          |
+|                          | the extension.           |                          |
+|                          |                          |                          |
+|                          | EXAMPLE:                 |                          |
+|                          | &lt;file&gt;sagepay&lt;/ |                          |
+|                          | file&gt;.                |                          |
+|                          | Extension zip file and   |                          |
+|                          | extension base directory |                          |
+|                          | contain *sagepay.php*    |                          |
++--------------------------+--------------------------+--------------------------+
+| **name**                 | name of the extension    | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **label**                | label of the extension.  | **NO**                   |
+|                          | For search extensions,   |                          |
+|                          | this tag is used as the  |                          |
+|                          | menu item text on Custom |                          |
+|                          | Searches list.           |                          |
++--------------------------+--------------------------+--------------------------+
+| **description**          | description of the       | **YES**                  |
+|                          | extension                |                          |
++--------------------------+--------------------------+--------------------------+
+| **urls**                 | a section containing all | **YES/NO**               |
+|                          | the urls that you think  |                          |
+|                          | are appropriate and      |                          |
+|                          | necessary for users to   |                          |
+|                          | find out more about what |                          |
+|                          | your extension does,     |                          |
+|                          | additional               |                          |
+|                          | documentation, etc. It's |                          |
+|                          | made of multiple **url** |                          |
+|                          | elements                 |                          |
++--------------------------+--------------------------+--------------------------+
+| general                  | **url** contains links   | **NO**                   |
+|                          | and has one attribute:   |                          |
+|                          | **desc** - the title to  |                          |
+|                          | be used when the link is |                          |
+|                          | displayed.               |                          |
++--------------------------+--------------------------+--------------------------+
+| documentation            | **&lt;url**              | **YES**                  |
+|                          | **desc="documentation"&g |                          |
+|                          | t;link                   |                          |
+|                          | to online documentation  |                          |
+|                          | here&lt;/url&gt;**       |                          |
++--------------------------+--------------------------+--------------------------+
+| **license**              | the name of the license  | **YES**                  |
+|                          | under which your         |                          |
+|                          | extension is offered.    |                          |
+|                          | For more information on  |                          |
+|                          | what license to choose,  |                          |
+|                          | see [CiviCRM licensing   |                          |
+|                          | page](http://civicrm.org |                          |
+|                          | /licensing){.external-li |                          |
+|                          | nk}.                     |                          |
+|                          | For technical details on |                          |
+|                          | how to identify a        |                          |
+|                          | license, see [SPDX       |                          |
+|                          | License                  |                          |
+|                          | List](http://www.spdx.or |                          |
+|                          | g/licenses/){.external-l |                          |
+|                          | ink}.                    |                          |
++--------------------------+--------------------------+--------------------------+
+| **maintainer**           | a section describing     | **YES**                  |
+|                          | maintainer information.  |                          |
+|                          | It has two elements:     |                          |
++--------------------------+--------------------------+--------------------------+
+|                          | **author** - name of the | **YES**                  |
+|                          | person and/or            |                          |
+|                          | organisation maintaining |                          |
+|                          | the extension            |                          |
++--------------------------+--------------------------+--------------------------+
+|                          | **email** - extension    | **YES**                  |
+|                          | maintainer's email       |                          |
+|                          | address                  |                          |
++--------------------------+--------------------------+--------------------------+
+| **releaseDate**          | date of release (use     | **YES**                  |
+|                          | *yyyy-mm-dd* format)     |                          |
++--------------------------+--------------------------+--------------------------+
+| **version**              | version of this          | **YES**                  |
+|                          | extension (used for      |                          |
+|                          | upgrade detection and    |                          |
+|                          | used to sort available   |                          |
+|                          | releases for automated   |                          |
+|                          | distribution)            |                          |
+|                          |                          |                          |
+|                          | Valid version formats    |                          |
+|                          | include:                 |                          |
+|                          |                          |                          |
+|                          |     '1', '1.1', '1.2.3.4 |                          |
+|                          | ', '1.2-3', '1.2.alpha2' |                          |
+|                          | , '1.2.rc2', '2012-01-01 |                          |
+|                          | -1', '2012-01-01', 'r456 |                          |
+|                          | ', 'r5000'               |                          |
++--------------------------+--------------------------+--------------------------+
+| **develStage**           | development stage - one  | **YES/NO**               |
+|                          | of: "stable", "beta",    |                          |
+|                          | "alpha". By default, the |                          |
+|                          | in-app distribution      |                          |
+|                          | system will only         |                          |
+|                          | publicize "stable"       |                          |
+|                          | releases.                |                          |
+|                          |                          |                          |
+|                          | If using  civicrm.org's  |                          |
+|                          | automated release        |                          |
+|                          | management (based on git |                          |
+|                          | tags), the               |                          |
+|                          | &lt;develStage&gt; will  |                          |
+|                          | be determined            |                          |
+|                          | automatically by         |                          |
+|                          | searching for "alpha" or |                          |
+|                          | "beta" in the version.   |                          |
++--------------------------+--------------------------+--------------------------+
+| **compatibility**        | section describing       | **YES**                  |
+|                          | CiviCRM version          |                          |
+|                          | compatibility, it's made |                          |
+|                          | of multiple **ver**      |                          |
+|                          | elements - one for each  |                          |
+|                          | supported CiviCRM        |                          |
+|                          | version, e.g.            |                          |
+|                          | &lt;ver&gt;4.2&lt;/ver&g |                          |
+|                          | t;&lt;ver&gt;4.3&lt;/ver |                          |
+|                          | &gt;                     |                          |
++--------------------------+--------------------------+--------------------------+
+|                          | **ver** - element        | **YES**                  |
+|                          | containing CiviCRM       |                          |
+|                          | version (two digits with |                          |
+|                          | a dot between them) that |                          |
+|                          | this extension is        |                          |
+|                          | compatible with, the     |                          |
+|                          | allowed values are       |                          |
+|                          | currently: 2.2, 3.0,     |                          |
+|                          | 3.1, 3.2, 3.3, 3.4, 4.0, |                          |
+|                          | 4.1, 4.2, 4.3, 4.4       |                          |
++--------------------------+--------------------------+--------------------------+
+| **comments**             | additional comments      | **NO**                   |
++--------------------------+--------------------------+--------------------------+
+| **typeInfo**             | section with type        | **YES/NO**               |
+|                          | specific extension       |                          |
+|                          | information. Each        |                          |
+|                          | extension type has       |                          |
+|                          | different set of fields  |                          |
+|                          | required here - please   |                          |
+|                          | refer to further parts   |                          |
+|                          | of this document for     |                          |
+|                          | details.                 |                          |
++--------------------------+--------------------------+--------------------------+
+
+</div>
+
+## Choose unique key for your extension
+
+Every extension has unique name called an **extension key**. It's built
+using Java-like reverse domain naming to make it easier to identify
+unique extensions.
+
+
+
+<div class="panelMacro">
+
++--+
+|  |
++--+
+
+</div>
+
+## Custom search specific typeInfo fields
+
+Custom search extensions do not require typeInfo section in the info.xml
+file.
+
+## Report template specific typeInfo fields
+
+<div class="table-wrap">
+
++--------------------------+--------------------------+--------------------------+
+| element name             | description              | required?                |
++==========================+==========================+==========================+
+| **reportUrl**            |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **reportUrl**            |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+
+</div>
+
+## Payment processor specific typeInfo fields
+
+<div class="table-wrap">
+
++--------------------------+--------------------------+--------------------------+
+| element name             | description              | required?                |
++==========================+==========================+==========================+
+| **userNameLabel**        |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **passwordLabel**        |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **signatureLabel**       |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **subjectLabel**         |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **urlSiteDefault**       |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **urlApiDefault**        |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **urlRecurDefault**      |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **urlSiteTestDefault**   |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **urlApiTestDefault**    |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **urlRecurTestDefault**  |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **urlButtonDefault**     |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **urlButtonTestDefault** |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **billingMode**          |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **isRecur**              |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+| **paymentType**          |                          | **YES**                  |
++--------------------------+--------------------------+--------------------------+
+
+</div>
+
+# Example XML - type = Module
+
+Module is the preferred extension type for 4.2+. Modules can include
+forms, form and pre/post processing modifications, custom searches,
+payment processors, reports and more. Prior versions of this page
+document the xml for the legacy format
+
+<div class="code panel" style="border-width: 1px;">
+
+<div class="codeContent panelContent">
+
+    <extension key="eu.tttp.exportexcel" type="module">
+      <file>exportexcel</file>
+      <downloadUrl>http://github.com/TechToThePeople/eu.tttp.excel/archive/master.zip</downloadUrl>
+      <name>Export to Excel</name>
+      <description>Excel isn't very good at importing csv files. If you have screamed at your computer with weird characters, long lines of gibberish and hair pulling, this extension is for you.
+     Technically, it isn't excel but an html table with a header that pretends to be excel. Close enough to trick excel to behave like it doesn't hate you too much.
+      </description>
+      <urls>
+        <url desc="Main Extension Page">http://github.com/TechToThePeople/eu.tttp.excel</url>
+        <url desc="Documentation">http://github.com/TechToThePeople/eu.tttp.excel</url>
+        <url desc="Support">http://forum.civicrm.org</url><url desc="Licensing">http://civicrm.org/licensing</url>
+      </urls>
+      <license>AGPL v3</license>
+      <maintainer>
+        <author>xavier dutoit</author>
+        <email>civicrm@tttp.eu</email>
+      </maintainer>
+      <releaseDate>2012-01-08</releaseDate>
+      <version>1.2</version>
+      <develStage>stable</develStage>
+      <compatibility>
+        <ver>4.1</ver>
+        <ver>4.2</ver>
+      </compatibility>
+      <comments>Enable the extension and export, that's it</comments>
+      <civix>
+        <namespace>CRM/Exportexcel</namespace>
+      </civix>
+    </extension>
+
+</div>
+
+</div>

--- a/docs/extensions/extension-reference.md
+++ b/docs/extensions/extension-reference.md
@@ -1,45 +1,5 @@
 # Extension Reference
 
-<div class="panel"
-style="background-color: #FFFFCE;border-color: #000;border-style: solid;border-width: 1px;">
-
-<div class="panelHeader"
-style="border-bottom-width: 1px;border-bottom-style: solid;border-bottom-color: #000;background-color: #F7D6C1;">
-
-**Table of Contents**
-
-</div>
-
-<div class="panelContent" style="background-color: #FFFFCE;">
-
-<div>
-
--   [Introduction](#ExtensionReference-Introduction)
--   [Changelog](#ExtensionReference-Changelog)
--   [Packaging](#ExtensionReference-Packaging)
--   [Tags in info.xml](#ExtensionReference-Tagsininfo.xml)
-
-<!-- -->
-
--   [Choose unique key for your
-    extension](#ExtensionReference-Chooseuniquekeyforyourextension)
--   [Custom search specific typeInfo
-    fields](#ExtensionReference-CustomsearchspecifictypeInfofields)
--   [Report template specific typeInfo
-    fields](#ExtensionReference-ReporttemplatespecifictypeInfofields)
--   [Payment processor specific typeInfo
-    fields](#ExtensionReference-PaymentprocessorspecifictypeInfofields)
-
-<!-- -->
-
--   [Example XML - type =
-    Module](#ExtensionReference-ExampleXML-type=Module)
-
-</div>
-
-</div>
-
-</div>
 
 # Introduction
 

--- a/docs/extensions/extension-reference.md
+++ b/docs/extensions/extension-reference.md
@@ -1,33 +1,28 @@
 # Extension Reference
 
-
-# Introduction
+## Introduction
 
 A ***native CiviCRM extension*** is a feature provided by a third-party
 developer which can be installed on CiviCRM. To support automated
 distribution and installation, an extension must be packaged according
 to a particular specification. This page documents the technical
 structure of an extension. For a proper introduction to developing
-extensions, see [Create an
-Extension](/confluence/display/CRMDOC/Create+an+Extension).
+extensions, see [Create an Extension](/extensions/index.md).
 
-# Changelog
+## Changelog
 
-<div class="table-wrap">
+| CiviCRM Version | Description |
+| -- | -- |
+| 4.5 | `<develStage>` is not always required; when using civicrm.org's automated release management, this value is inferred from the version; for manual or private releases, the field should still be defined.
+| 4.2 | Most extensions should be packaged as generic *module* rather than type-specific extensions.
+| 4.2 | `<downloadUrl>` is optional for ordinary development; when using civicrm.org to distribute extensions, the `<downloadUrl>` will be specified when announcing the release on the website
+| 4.2 | `<downloadUrl>` can point to auto-generated zipballs on Github.com
+| 4.2 | Introduce stable support for generic modules.
+| 4.1 | Introduce experimental extension-type for generic modules.
+| 3.3 | Introduce extension-types for payment-processors, report-templates, and custom-searches.
 
-  CiviCRM Version   Description
-  ----------------- ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  4.5               &lt;develStage&gt; is not always required; when using civicrm.org's automated release management, this value is inferred from the version; for manual or private releases, the field should still be defined.
-  4.2               Most extensions should be packaged as generic *module* rather than type-specific extensions.
-  4.2               &lt;downloadUrl&gt; is optional for ordinary development; when using civicrm.org to distribute extensions, the &lt;downloadUrl&gt; will be specified when announcing the release on the website
-  4.2               &lt;downloadUrl&gt; can point to auto-generated zipballs on Github.com
-  4.2               Introduce stable support for generic modules.
-  4.1               Introduce experimental extension-type for generic modules*.*
-  3.3               Introduce extension-types for payment-processors, report-templates, and custom-searches.
 
-</div>
-
-# Packaging
+## Packaging
 
 For redistribution, an extension must be packaged as a .zip file which
 meets these requirements:
@@ -36,12 +31,11 @@ meets these requirements:
     folder should match the extension's unique key. (In 4.1 and earlier,
     the matched name was mandatory. In 4.2 and later, the matched name
     is optional.)
--   The folder must include a file named "info.xml" which meets the
+-   The folder must include a file named `info.xml` which meets the
     specification below.
 
-# Tags in info.xml
+## Tags in info.xml
 
-<div class="table-wrap">
 
 +--------------------------+--------------------------+--------------------------+
 | element name             | description              | required?                |
@@ -110,8 +104,8 @@ meets these requirements:
 |                          | the extension.           |                          |
 |                          |                          |                          |
 |                          | EXAMPLE:                 |                          |
-|                          | &lt;file&gt;sagepay&lt;/ |                          |
-|                          | file&gt;.                |                          |
+|                          | <file>sagepay</ |                          |
+|                          | file>.                |                          |
 |                          | Extension zip file and   |                          |
 |                          | extension base directory |                          |
 |                          | contain *sagepay.php*    |                          |
@@ -144,11 +138,11 @@ meets these requirements:
 |                          | be used when the link is |                          |
 |                          | displayed.               |                          |
 +--------------------------+--------------------------+--------------------------+
-| documentation            | **&lt;url**              | **YES**                  |
+| documentation            | **<url**              | **YES**                  |
 |                          | **desc="documentation"&g |                          |
 |                          | t;link                   |                          |
 |                          | to online documentation  |                          |
-|                          | here&lt;/url&gt;**       |                          |
+|                          | here</url>**       |                          |
 +--------------------------+--------------------------+--------------------------+
 | **license**              | the name of the license  | **YES**                  |
 |                          | under which your         |                          |
@@ -211,7 +205,7 @@ meets these requirements:
 |                          | automated release        |                          |
 |                          | management (based on git |                          |
 |                          | tags), the               |                          |
-|                          | &lt;develStage&gt; will  |                          |
+|                          | <develStage> will  |                          |
 |                          | be determined            |                          |
 |                          | automatically by         |                          |
 |                          | searching for "alpha" or |                          |
@@ -224,9 +218,9 @@ meets these requirements:
 |                          | elements - one for each  |                          |
 |                          | supported CiviCRM        |                          |
 |                          | version, e.g.            |                          |
-|                          | &lt;ver&gt;4.2&lt;/ver&g |                          |
-|                          | t;&lt;ver&gt;4.3&lt;/ver |                          |
-|                          | &gt;                     |                          |
+|                          | <ver>4.2</ver&g |                          |
+|                          | t;<ver>4.3</ver |                          |
+|                          | >                     |                          |
 +--------------------------+--------------------------+--------------------------+
 |                          | **ver** - element        | **YES**                  |
 |                          | containing CiviCRM       |                          |
@@ -252,7 +246,6 @@ meets these requirements:
 |                          | details.                 |                          |
 +--------------------------+--------------------------+--------------------------+
 
-</div>
 
 ## Choose unique key for your extension
 
@@ -260,15 +253,10 @@ Every extension has unique name called an **extension key**. It's built
 using Java-like reverse domain naming to make it easier to identify
 unique extensions.
 
+Extension key examples
 
-
-<div class="panelMacro">
-
-+--+
-|  |
-+--+
-
-</div>
+* If your website is `circleinteractive.co.uk`, and you've developed a payment processor plugin for Sagepay, your extension key might be: `uk.co.circleinteractive.payment.sagepay`
+* If your website is `civiconsulting.com`, and you're developing a custom search for event registration, your extension key might be: `com.civiconsulting.search.eventregistration`.
 
 ## Custom search specific typeInfo fields
 
@@ -277,7 +265,6 @@ file.
 
 ## Report template specific typeInfo fields
 
-<div class="table-wrap">
 
 +--------------------------+--------------------------+--------------------------+
 | element name             | description              | required?                |
@@ -287,11 +274,9 @@ file.
 | **reportUrl**            |                          | **YES**                  |
 +--------------------------+--------------------------+--------------------------+
 
-</div>
 
 ## Payment processor specific typeInfo fields
 
-<div class="table-wrap">
 
 +--------------------------+--------------------------+--------------------------+
 | element name             | description              | required?                |
@@ -327,49 +312,42 @@ file.
 | **paymentType**          |                          | **YES**                  |
 +--------------------------+--------------------------+--------------------------+
 
-</div>
 
-# Example XML - type = Module
+## Example XML - type = Module
 
 Module is the preferred extension type for 4.2+. Modules can include
 forms, form and pre/post processing modifications, custom searches,
 payment processors, reports and more. Prior versions of this page
 document the xml for the legacy format
 
-<div class="code panel" style="border-width: 1px;">
-
-<div class="codeContent panelContent">
-
-    <extension key="eu.tttp.exportexcel" type="module">
-      <file>exportexcel</file>
-      <downloadUrl>http://github.com/TechToThePeople/eu.tttp.excel/archive/master.zip</downloadUrl>
-      <name>Export to Excel</name>
-      <description>Excel isn't very good at importing csv files. If you have screamed at your computer with weird characters, long lines of gibberish and hair pulling, this extension is for you.
-     Technically, it isn't excel but an html table with a header that pretends to be excel. Close enough to trick excel to behave like it doesn't hate you too much.
-      </description>
-      <urls>
-        <url desc="Main Extension Page">http://github.com/TechToThePeople/eu.tttp.excel</url>
-        <url desc="Documentation">http://github.com/TechToThePeople/eu.tttp.excel</url>
-        <url desc="Support">http://forum.civicrm.org</url><url desc="Licensing">http://civicrm.org/licensing</url>
-      </urls>
-      <license>AGPL v3</license>
-      <maintainer>
-        <author>xavier dutoit</author>
-        <email>civicrm@tttp.eu</email>
-      </maintainer>
-      <releaseDate>2012-01-08</releaseDate>
-      <version>1.2</version>
-      <develStage>stable</develStage>
-      <compatibility>
-        <ver>4.1</ver>
-        <ver>4.2</ver>
-      </compatibility>
-      <comments>Enable the extension and export, that's it</comments>
-      <civix>
-        <namespace>CRM/Exportexcel</namespace>
-      </civix>
-    </extension>
-
-</div>
-
-</div>
+```xml
+<extension key="eu.tttp.exportexcel" type="module">
+  <file>exportexcel</file>
+  <downloadUrl>http://github.com/TechToThePeople/eu.tttp.excel/archive/master.zip</downloadUrl>
+  <name>Export to Excel</name>
+  <description>Excel isn't very good at importing csv files. If you have screamed at your computer with weird characters, long lines of gibberish and hair pulling, this extension is for you.
+ Technically, it isn't excel but an html table with a header that pretends to be excel. Close enough to trick excel to behave like it doesn't hate you too much.
+  </description>
+  <urls>
+    <url desc="Main Extension Page">http://github.com/TechToThePeople/eu.tttp.excel</url>
+    <url desc="Documentation">http://github.com/TechToThePeople/eu.tttp.excel</url>
+    <url desc="Support">http://forum.civicrm.org</url><url desc="Licensing">http://civicrm.org/licensing</url>
+  </urls>
+  <license>AGPL v3</license>
+  <maintainer>
+    <author>xavier dutoit</author>
+    <email>civicrm@tttp.eu</email>
+  </maintainer>
+  <releaseDate>2012-01-08</releaseDate>
+  <version>1.2</version>
+  <develStage>stable</develStage>
+  <compatibility>
+    <ver>4.1</ver>
+    <ver>4.2</ver>
+  </compatibility>
+  <comments>Enable the extension and export, that's it</comments>
+  <civix>
+    <namespace>CRM/Exportexcel</namespace>
+  </civix>
+</extension>
+```

--- a/docs/extensions/info-xml.md
+++ b/docs/extensions/info-xml.md
@@ -1,330 +1,356 @@
 # info.xml
 
-## Introduction
+Every CiviCRM [extension](/extensions/index.md) must have an `info.xml` file within it to provide information about the extension. This page is a reference for the schema of the `info.xml` file.
 
-A ***native CiviCRM extension*** is a feature provided by a third-party
-developer which can be installed on CiviCRM. To support automated
-distribution and installation, an extension must be packaged according
-to a particular specification. This page documents the technical
-structure of an extension. For a proper introduction to developing
-extensions, see [Create an Extension](/extensions/index.md).
+Typically, you'll begin by running [civix generate:module](/extensions/civix.md#generate-module) and `civix` will create a basic `info.xml` file for you. Use this page to learn how to customize that file.
+
+## Example
+
+Here is an example of a full `info.xml` file from [CiviVolunteer](https://github.com/civicrm/org.civicrm.volunteer/blob/master/info.xml).
+
+```xml
+<?xml version="1.0"?>
+<extension key="org.civicrm.volunteer" type="module">
+  <file>volunteer</file>
+  <name>CiviVolunteer</name>
+  <description>The CiviVolunteer extension provides tools for signing up, managing, and tracking volunteers.</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>Ginkgo Street Labs; CiviCRM, LLC; and the CiviCRM community</author>
+    <email>inquire@ginkgostreet.com</email>
+  </maintainer>
+  <releaseDate>2016-12-06</releaseDate>
+  <version>4.6-2.2.1</version>
+  <develStage>stable</develStage>
+  <compatibility>
+    <ver>4.6</ver>
+    <ver>4.7</ver>
+  </compatibility>
+  <comments>
+    Developed by Ginkgo Street Labs and CiviCRM, LLC with contributions from the community. Special thanks to Friends of Georgia State Parks &amp; Historic Sites for funding the initial release, and to The Manhattan Neighborhood Network for funding the 1.4 release.
+  </comments>
+  <civix>
+    <namespace>CRM/Volunteer</namespace>
+  </civix>
+  <urls>
+    <url desc="Documentation">https://docs.civicrm.org/volunteer/en/latest</url>
+  </urls>
+</extension>
+```
 
 ## Changelog
 
 | CiviCRM Version | Description |
 | -- | -- |
-| 4.5 | `<develStage>` is not always required; when using civicrm.org's automated release management, this value is inferred from the version; for manual or private releases, the field should still be defined.
+| 4.5 | [`<develStage>`](#develStage) is not always required; when using civicrm.org's automated release management, this value is inferred from the version; for manual or private releases, the field should still be defined.
 | 4.2 | Most extensions should be packaged as generic *module* rather than type-specific extensions.
-| 4.2 | `<downloadUrl>` is optional for ordinary development; when using civicrm.org to distribute extensions, the `<downloadUrl>` will be specified when announcing the release on the website
-| 4.2 | `<downloadUrl>` can point to auto-generated zipballs on Github.com
+| 4.2 | [`<downloadUrl>`](#downloadUrl) is optional for ordinary development; when using civicrm.org to distribute extensions, the [`<downloadUrl>`](#downloadUrl) will be specified when announcing the release on the website
+| 4.2 | [`<downloadUrl>`](#downloadUrl) can point to auto-generated zipballs on Github.com
 | 4.2 | Introduce stable support for generic modules.
 | 4.1 | Introduce experimental extension-type for generic modules.
 | 3.3 | Introduce extension-types for payment-processors, report-templates, and custom-searches.
 
+## Elements
 
-## Tags in info.xml
+Here we describe all the elements acceptable within the XML file. They are presented in alphabetical order, but note that **the root element must be [`<extension>`](#extension)**, so you might wish to [begin reading about `<extension>` first](#extension).
 
+### `<author>` {:#author}
 
-+--------------------------+--------------------------+--------------------------+
-| element name             | description              | required?                |
-+==========================+==========================+==========================+
-| **extension**            | enclosing element for    | **YES**                  |
-|                          | all the information in   |                          |
-|                          | info.xml - everything    |                          |
-|                          | needs to sit inside of   |                          |
-|                          | it. Attributes are:      |                          |
-|                          |                          |                          |
-|                          | 1.  **key**: unique name |                          |
-|                          |     of the extension     |                          |
-|                          |     (should match the    |                          |
-|                          |     name of directory    |                          |
-|                          |     this extension       |                          |
-|                          |     resides in). See     |                          |
-|                          |     information on       |                          |
-|                          |     choosing the         |                          |
-|                          |     extension key below  |                          |
-|                          |     for                  |                          |
-|                          |     more information.    |                          |
-|                          | 2.  **type**: one of     |                          |
-|                          |     "module", "search",  |                          |
-|                          |     "payment", "report", |                          |
-|                          |     meaning that this    |                          |
-|                          |     extension is -       |                          |
-|                          |     respectively - a     |                          |
-|                          |     custom module,       |                          |
-|                          |     search, payment      |                          |
-|                          |     processor or         |                          |
-|                          |     custom report.       |                          |
-+--------------------------+--------------------------+--------------------------+
-| **downloadUrl**          | the url to the zip file  | **NO\                    |
-|                          | with your extension.     | **                       |
-|                          |                          |                          |
-|                          | *NOTE: Prior to CiviCRM  |                          |
-|                          | 4.2, the downloadUrl was |                          |
-|                          | mandatory in info.xml.   |                          |
-|                          | It needed to point to a  |                          |
-|                          | plain .zip file whose    |                          |
-|                          | content included a base  |                          |
-|                          | folder; and it was       |                          |
-|                          | mandatory for the base   |                          |
-|                          | folder to be named after |                          |
-|                          | the extension.\          |                          |
-|                          | *                        |                          |
-|                          |                          |                          |
-|                          | *NOTE: Beginning with    |                          |
-|                          | CiviCRM 4.2, developers  |                          |
-|                          | should not normally      |                          |
-|                          | include the downloadUrl. |                          |
-|                          | The information will     |                          |
-|                          | only be required when    |                          |
-|                          | submitting a new release |                          |
-|                          | on civicrm.org.\         |                          |
-|                          | *                        |                          |
-+--------------------------+--------------------------+--------------------------+
-| **file**                 | the name of the file to  | **YES**                  |
-|                          | invoke when extension is |                          |
-|                          | executed (not including  |                          |
-|                          | .php file extension).    |                          |
-|                          | This file must be        |                          |
-|                          | present in the root of   |                          |
-|                          | the extension .zip file  |                          |
-|                          | / in base directory of   |                          |
-|                          | the extension.           |                          |
-|                          |                          |                          |
-|                          | EXAMPLE:                 |                          |
-|                          | <file>sagepay</ |                          |
-|                          | file>.                |                          |
-|                          | Extension zip file and   |                          |
-|                          | extension base directory |                          |
-|                          | contain *sagepay.php*    |                          |
-+--------------------------+--------------------------+--------------------------+
-| **name**                 | name of the extension    | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **label**                | label of the extension.  | **NO**                   |
-|                          | For search extensions,   |                          |
-|                          | this tag is used as the  |                          |
-|                          | menu item text on Custom |                          |
-|                          | Searches list.           |                          |
-+--------------------------+--------------------------+--------------------------+
-| **description**          | description of the       | **YES**                  |
-|                          | extension                |                          |
-+--------------------------+--------------------------+--------------------------+
-| **urls**                 | a section containing all | **YES/NO**               |
-|                          | the urls that you think  |                          |
-|                          | are appropriate and      |                          |
-|                          | necessary for users to   |                          |
-|                          | find out more about what |                          |
-|                          | your extension does,     |                          |
-|                          | additional               |                          |
-|                          | documentation, etc. It's |                          |
-|                          | made of multiple **url** |                          |
-|                          | elements                 |                          |
-+--------------------------+--------------------------+--------------------------+
-| general                  | **url** contains links   | **NO**                   |
-|                          | and has one attribute:   |                          |
-|                          | **desc** - the title to  |                          |
-|                          | be used when the link is |                          |
-|                          | displayed.               |                          |
-+--------------------------+--------------------------+--------------------------+
-| documentation            | **<url**              | **YES**                  |
-|                          | **desc="documentation"&g |                          |
-|                          | t;link                   |                          |
-|                          | to online documentation  |                          |
-|                          | here</url>**       |                          |
-+--------------------------+--------------------------+--------------------------+
-| **license**              | the name of the license  | **YES**                  |
-|                          | under which your         |                          |
-|                          | extension is offered.    |                          |
-|                          | For more information on  |                          |
-|                          | what license to choose,  |                          |
-|                          | see [CiviCRM licensing   |                          |
-|                          | page](http://civicrm.org |                          |
-|                          | /licensing){.external-li |                          |
-|                          | nk}.                     |                          |
-|                          | For technical details on |                          |
-|                          | how to identify a        |                          |
-|                          | license, see [SPDX       |                          |
-|                          | License                  |                          |
-|                          | List](http://www.spdx.or |                          |
-|                          | g/licenses/){.external-l |                          |
-|                          | ink}.                    |                          |
-+--------------------------+--------------------------+--------------------------+
-| **maintainer**           | a section describing     | **YES**                  |
-|                          | maintainer information.  |                          |
-|                          | It has two elements:     |                          |
-+--------------------------+--------------------------+--------------------------+
-|                          | **author** - name of the | **YES**                  |
-|                          | person and/or            |                          |
-|                          | organisation maintaining |                          |
-|                          | the extension            |                          |
-+--------------------------+--------------------------+--------------------------+
-|                          | **email** - extension    | **YES**                  |
-|                          | maintainer's email       |                          |
-|                          | address                  |                          |
-+--------------------------+--------------------------+--------------------------+
-| **releaseDate**          | date of release (use     | **YES**                  |
-|                          | *yyyy-mm-dd* format)     |                          |
-+--------------------------+--------------------------+--------------------------+
-| **version**              | version of this          | **YES**                  |
-|                          | extension (used for      |                          |
-|                          | upgrade detection and    |                          |
-|                          | used to sort available   |                          |
-|                          | releases for automated   |                          |
-|                          | distribution)            |                          |
-|                          |                          |                          |
-|                          | Valid version formats    |                          |
-|                          | include:                 |                          |
-|                          |                          |                          |
-|                          |     '1', '1.1', '1.2.3.4 |                          |
-|                          | ', '1.2-3', '1.2.alpha2' |                          |
-|                          | , '1.2.rc2', '2012-01-01 |                          |
-|                          | -1', '2012-01-01', 'r456 |                          |
-|                          | ', 'r5000'               |                          |
-+--------------------------+--------------------------+--------------------------+
-| **develStage**           | development stage - one  | **YES/NO**               |
-|                          | of: "stable", "beta",    |                          |
-|                          | "alpha". By default, the |                          |
-|                          | in-app distribution      |                          |
-|                          | system will only         |                          |
-|                          | publicize "stable"       |                          |
-|                          | releases.                |                          |
-|                          |                          |                          |
-|                          | If using  civicrm.org's  |                          |
-|                          | automated release        |                          |
-|                          | management (based on git |                          |
-|                          | tags), the               |                          |
-|                          | <develStage> will  |                          |
-|                          | be determined            |                          |
-|                          | automatically by         |                          |
-|                          | searching for "alpha" or |                          |
-|                          | "beta" in the version.   |                          |
-+--------------------------+--------------------------+--------------------------+
-| **compatibility**        | section describing       | **YES**                  |
-|                          | CiviCRM version          |                          |
-|                          | compatibility, it's made |                          |
-|                          | of multiple **ver**      |                          |
-|                          | elements - one for each  |                          |
-|                          | supported CiviCRM        |                          |
-|                          | version, e.g.            |                          |
-|                          | <ver>4.2</ver&g |                          |
-|                          | t;<ver>4.3</ver |                          |
-|                          | >                     |                          |
-+--------------------------+--------------------------+--------------------------+
-|                          | **ver** - element        | **YES**                  |
-|                          | containing CiviCRM       |                          |
-|                          | version (two digits with |                          |
-|                          | a dot between them) that |                          |
-|                          | this extension is        |                          |
-|                          | compatible with, the     |                          |
-|                          | allowed values are       |                          |
-|                          | currently: 2.2, 3.0,     |                          |
-|                          | 3.1, 3.2, 3.3, 3.4, 4.0, |                          |
-|                          | 4.1, 4.2, 4.3, 4.4       |                          |
-+--------------------------+--------------------------+--------------------------+
-| **comments**             | additional comments      | **NO**                   |
-+--------------------------+--------------------------+--------------------------+
-| **typeInfo**             | section with type        | **YES/NO**               |
-|                          | specific extension       |                          |
-|                          | information. Each        |                          |
-|                          | extension type has       |                          |
-|                          | different set of fields  |                          |
-|                          | required here - please   |                          |
-|                          | refer to further parts   |                          |
-|                          | of this document for     |                          |
-|                          | details.                 |                          |
-+--------------------------+--------------------------+--------------------------+
+* Containing element: [`<maintainer>`](#maintainer)
+* Description: Name of the person and/or organisation maintaining the extension
+* Contains: text
 
+### `<billingMode>` {:#billingMode}
 
-## Custom search specific typeInfo fields
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
 
-Custom search extensions do not require typeInfo section in the info.xml
-file.
+### `<comments>` {:#comments}
 
-## Report template specific typeInfo fields
+* Containing element: [`<extension>`](#extension)
+* Description: A long description of the extension that will display to the user before installation.
+* Contains: text
 
+### `<compatibility>` {:#compatibility}
 
-+--------------------------+--------------------------+--------------------------+
-| element name             | description              | required?                |
-+==========================+==========================+==========================+
-| **reportUrl**            |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **reportUrl**            |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
+* Containing element: [`<extension>`](#extension)
+* Description: specifies the versions of CiviCRM which which this extension is compatible
+* Contains: elements
 
+Elements acceptable within `<compatibility>`
 
-## Payment processor specific typeInfo fields
+| Element | Acceptable instances | 
+| -- | -- |
+| [`<ver>`](#ver) | 1+ |
+
+### `<description>` {:#description}
+
+* Containing element: [`<extension>`](#extension)
+* Description: A brief (one sentence) human-readable description of what the extension does
+* Contains: text
+
+### `<develStage>` {:#develStage}
+
+* Containing element: [`<extension>`](#extension)
+* Description: development stage
+* Contains: text
+* Acceptable values: `stable`, `beta`, `alpha`
+* Notes: 
+    * If you want your extension to be available for [automated distribution](/extensions/publish.md#automated-distribution), it must be marked as `stable`.
+    * If you use civicrm.org's automated release management (based on git tags), the `<develStage>` value will be determined automatically by searching for "alpha" or "beta" in the version.
+
+### `<downloadUrl>` {:#downloadUrl}
+
+* Containing element: [`<extension>`](#extension)
+* Description: The url to the zip file with your extension.
+* Contains: text
+
+!!! failure "Deprecated"
+    `<downloadUrl>` was deprecated in CiviCRM 4.2
+
+### `<email>` {:#email}
+
+* Containing element: [`<maintainer>`](#maintainer)
+* Description: The maintainer's email address
+* Contains: text
+
+### `<extension>` {:#extension}
+
+* Containing element: None. This is the root element of `info.xml`.
+* Description: Describe one extension
+* Contains: elements
+
+Attributes acceptable for `<extension>`
+
+| Attribute | Description |
+| -- | -- |
+| `key` | The unique name of the extension, e.g. `org.example.myextension`. It should match the name of directory this extension resides in. Read more about [choosing a name](/extensions/index.md#extension-names). |
+| `type` | One of `module`, `search`, `payment`, `report`. |
+
+Elements acceptable within `<extension>`
+
+| Element | Acceptable instances | Acceptable<br>when |
+| -- | -- | -- |
+| [`<compatibility>`](#compatibility) | 1 |  |
+| [`<comments>`](#comments) | 0 or 1 |  |
+| [`<description>`](#description) | 1 |  |
+| [`<develStage>`](#develStage) | 0 or 1 |  |
+| ~~[`<downloadUrl>`](#downloadUrl)~~ | 0 |  |
+| [`<file>`](#file) | 1 |  |
+| [`<label>`](#label) | 0 or 1 | `<extention type="search">` |
+| [`<license>`](#license) | 1 |  |
+| [`<maintainer>`](#maintainer) | 1 |  |
+| [`<name>`](#name)| 1 |  |
+| [`<releaseDate>`](#releaseDate) | 1 |  |
+| [`<typeInfo>`](#typeInfo) | 0 or 1 |  |
+| [`<urls>`](#urls) | 1 |  |
+| [`<version>`](#version) | 1 |  |
+
+### `<file>` {:#file}
+
+* Containing element: [`<extension>`](#extension)
+* Description: The name of the file to invoke when the extension is executed (not including `.php` file extension) This file must be present in the root of the extension `.zip` file / in base directory of the extension
+* Contains: text
+
+### `<isRecur>` {:#isRecur}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<label>` {:#label}
+
+* Containing element: [`<extension>`](#extension)
+* Description: For search extensions, this element is used as the menu item text on Custom Searches list
+* Contains: text
+
+### `<license>` {:#license}
+
+* Containing element: [`<extension>`](#extension)
+* Description: The name of the license under which your extension is offered.
+* Contains: text
+* Example: `AGPL-3.0`
+
+!!! tip
+    For more information on what license to choose, see [CiviCRM licensing page](http://civicrm.org/licensing). For technical details on how to identify a license, see [SPDX License List](http://www.spdx.org/licenses/)
+
+### `<maintainer>` {:#extension-maintainer}
+
+* Containing element: [`<extension>`](#extension)
+* Description: Used to store information about the person (or organization maintaining the extension)
+* Contains: elements
+
+Elements acceptable within `<maintainer>`
+
+| Element | Acceptable instances |
+| -- | -- |
+| [`<author>`](#author) | 1 |
+| [`<email>`](#email) | 1 |
+
+### `<name>` {:#name}
+
+* Containing element: [`<extension>`](#extension)
+* Description: Human-readable name of the extension. It can contain spaces
+* Contains: text
+
+### `<passwordLabel>` {:#passwordLabel}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<paymentType>` {:#paymentType}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<releaseDate>` {:#releaseDate}
+
+* Containing element: [`<extension>`](#extension)
+* Description: The release date of the current version (use `YYYY-MM-DD` format)
+* Contains: text
+
+### `<reportUrl>` {:#reportUrl}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<signatureLabel>` {:#signatureLabel}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<subjectLabel>` {:#subjectLabel}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<typeInfo>` {:#typeInfo}
+
+* Containing element: [`<extension>`](#extension)
+* Description: This is a container tag for other tags which store information that is only relevant to extensions of particular types (e.g. payment processor extensions)
+* Contains: elements
+
+Elements acceptable within `<typeInfo>`
+
+| Element | Acceptable instances | Acceptable<br>when |
+| -- | -- | -- |
+| [`<reportUrl>`](#reportUrl) | 0 or 1 | `<extension type="report">` |
+| [`<userNameLabel>`](#userNameLabel) | 0 or 1 | `<extension type="payment">` |
+| [`<passwordLabel>`](#passwordLabel) | 0 or 1 | `<extension type="payment">` |
+| [`<signatureLabel>`](#signatureLabel) | 0 or 1 | `<extension type="payment">` |
+| [`<subjectLabel>`](#subjectLabel) | 0 or 1 | `<extension type="payment">` |
+| [`<urlSiteDefault>`](#urlSiteDefault) | 0 or 1 | `<extension type="payment">` |
+| [`<urlApiDefault>`](#urlApiDefault) | 0 or 1 | `<extension type="payment">` |
+| [`<urlRecurDefault>`](#urlRecurDefault) | 0 or 1 | `<extension type="payment">` |
+| [`<urlSiteTestDefault>`](#urlSiteTestDefault) | 0 or 1 | `<extension type="payment">` |
+| [`<urlApiTestDefault>`](#urlApiTestDefault) | 0 or 1 | `<extension type="payment">` |
+| [`<urlRecurTestDefault>`](#urlRecurTestDefault) | 0 or 1 | `<extension type="payment">` |
+| [`<urlButtonDefault>`](#urlButtonDefault) | 0 or 1 | `<extension type="payment">` |
+| [`<urlButtonTestDefault>`](#urlButtonTestDefault) | 0 or 1 | `<extension type="payment">` |
+| [`<billingMode>`](#billingMode) | 0 or 1 | `<extension type="payment">` |
+| [`<isRecur>`](#isRecur) | 0 or 1 | `<extension type="payment">` |
+| [`<paymentType>`](#paymentType) | 0 or 1 | `<extension type="payment">` |
+
+### `<url>` {:#url}
+
+* Containing element: [`<urls>`](#urls)
+* Description: Represents one URL which is associated with this extension. For example, the URL of the extension's documentation.
+* Contains: text
+
+Attributes acceptable for `<url>`
+
+| Attribute | Contains |  Purpose |
+| -- | -- | -- |
+| `desc` | text | A short (usually one word) description of the URL. This will display next to the URL in the CiviCRM UI before users install the extension. For example "Documentation" and "Support" are common values. |
+
+### `<urls>` {:#urls}
+
+* Containing element: [`<extension>`](#extension)
+* Description: Stores all the urls that you think are appropriate and necessary for users to find out more about what your extension does, additional documentation, etc.
+* Contains: elements
+
+Elements acceptable within `<urls>`
+
+| Element | Acceptable instances |
+| -- | -- |
+| [`<url>`](#url) | 1 |
 
 
-+--------------------------+--------------------------+--------------------------+
-| element name             | description              | required?                |
-+==========================+==========================+==========================+
-| **userNameLabel**        |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **passwordLabel**        |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **signatureLabel**       |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **subjectLabel**         |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **urlSiteDefault**       |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **urlApiDefault**        |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **urlRecurDefault**      |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **urlSiteTestDefault**   |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **urlApiTestDefault**    |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **urlRecurTestDefault**  |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **urlButtonDefault**     |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **urlButtonTestDefault** |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **billingMode**          |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **isRecur**              |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
-| **paymentType**          |                          | **YES**                  |
-+--------------------------+--------------------------+--------------------------+
+### `<urlSiteDefault>` {:#urlSiteDefault}
 
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
 
-## Example XML - type = Module
+### `<urlApiDefault>` {:#urlApiDefault}
 
-Module is the preferred extension type for 4.2+. Modules can include
-forms, form and pre/post processing modifications, custom searches,
-payment processors, reports and more. Prior versions of this page
-document the xml for the legacy format
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
 
-```xml
-<extension key="eu.tttp.exportexcel" type="module">
-  <file>exportexcel</file>
-  <downloadUrl>http://github.com/TechToThePeople/eu.tttp.excel/archive/master.zip</downloadUrl>
-  <name>Export to Excel</name>
-  <description>Excel isn't very good at importing csv files. If you have screamed at your computer with weird characters, long lines of gibberish and hair pulling, this extension is for you.
- Technically, it isn't excel but an html table with a header that pretends to be excel. Close enough to trick excel to behave like it doesn't hate you too much.
-  </description>
-  <urls>
-    <url desc="Main Extension Page">http://github.com/TechToThePeople/eu.tttp.excel</url>
-    <url desc="Documentation">http://github.com/TechToThePeople/eu.tttp.excel</url>
-    <url desc="Support">http://forum.civicrm.org</url><url desc="Licensing">http://civicrm.org/licensing</url>
-  </urls>
-  <license>AGPL v3</license>
-  <maintainer>
-    <author>xavier dutoit</author>
-    <email>civicrm@tttp.eu</email>
-  </maintainer>
-  <releaseDate>2012-01-08</releaseDate>
-  <version>1.2</version>
-  <develStage>stable</develStage>
-  <compatibility>
-    <ver>4.1</ver>
-    <ver>4.2</ver>
-  </compatibility>
-  <comments>Enable the extension and export, that's it</comments>
-  <civix>
-    <namespace>CRM/Exportexcel</namespace>
-  </civix>
-</extension>
-```
+### `<urlRecurDefault>` {:#urlRecurDefault}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<urlSiteTestDefault>` {:#urlSiteTestDefault}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<urlApiTestDefault>` {:#urlApiTestDefault}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<urlRecurTestDefault>` {:#urlRecurTestDefault}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<urlButtonDefault>` {:#urlButtonDefault}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<urlButtonTestDefault>` {:#urlButtonTestDefault}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<ver>` {:#ver}
+
+* Containing element: [`<compatibility>`](#compatibility)
+* Description: a version of CiviCRM with which this extension is compatible
+* Contains: text
+* Example: `4.7`
+
+!!! note
+    It is not currently possible to specify compatibility with point releases. If your extension is compatible with CiviCRM 4.7.21 but *not* 4.7.20, then you will need to clearly specify this in the [comments](#comments).
+    
+### `<userNameLabel>` {:#userNameLabel}
+
+* Containing element: [`<typeInfo>`](#typeInfo)
+* Description: *not yet documented*
+* Contains: text
+
+### `<version>` {:#version}
+
+* Containing element: [`<extension>`](#extension)
+* Description: The current version of this extension (used for upgrade detection and used to sort available releases for automated distribution)
+* Contains: text
+
+Valid version formats include: `1`, `1.1`, `1.2.3.4`, `1.2-3`, `1.2.alpha2` , `1.2.rc2`, `2012-01-01-1`, `2012-01-01`, `r456 `, `r5000`
+

--- a/docs/extensions/info-xml.md
+++ b/docs/extensions/info-xml.md
@@ -299,7 +299,7 @@ Elements acceptable within `<urls>`
 
 | Element | Acceptable instances |
 | -- | -- |
-| [`<url>`](#url) | 1 |
+| [`<url>`](#url) | 1+ |
 
 
 ### `<urlSiteDefault>` {:#urlSiteDefault}

--- a/docs/extensions/info-xml.md
+++ b/docs/extensions/info-xml.md
@@ -78,6 +78,18 @@ Elements acceptable within `<civix>`
 | -- | -- |
 | [`<namespace>`](#namespace) | 1 |
 
+### `<classloader>` {:#classloader}
+
+* Containing element: [`<extension>`](#extension)
+* Description: *not yet documented* 
+* Contains: elements
+
+Elements acceptable within `<classloader>`
+
+| Element | Acceptable instances | 
+| -- | -- |
+| [`<psr4>`](#psr4) | ? |
+
 ### `<comments>` {:#comments}
 
 * Containing element: [`<extension>`](#extension)
@@ -127,6 +139,13 @@ Elements acceptable within `<compatibility>`
 * Description: The maintainer's email address
 * Contains: text
 
+### `<ext>` {:#ext}
+
+* Containing element: [`<requires>`](#requires)
+* Description: Specifies the unique name of one extension on which this extension is dependent.
+* Contains: text
+* Example: `org.civicrm.shoreditch`
+
 ### `<extension>` {:#extension}
 
 * Containing element: None. This is the root element of `info.xml`.
@@ -145,6 +164,7 @@ Elements acceptable within `<extension>`
 | Element | Acceptable instances | Acceptable<br>when |
 | -- | -- | -- |
 | [`<civix>`](#civix) | 0 or 1 |  |
+| [`<classloader>`](#classloader) | 0 or 1 |  |
 | [`<compatibility>`](#compatibility) | 1 |  |
 | [`<comments>`](#comments) | 0 or 1 |  |
 | [`<description>`](#description) | 1 |  |
@@ -156,6 +176,7 @@ Elements acceptable within `<extension>`
 | [`<maintainer>`](#maintainer) | 1 |  |
 | [`<name>`](#name)| 1 |  |
 | [`<releaseDate>`](#releaseDate) | 1 |  |
+| [`<requires>`](#requires) | 0 or 1 |  |
 | [`<typeInfo>`](#typeInfo) | 0 or 1 |  |
 | [`<urls>`](#urls) | 1 |  |
 | [`<version>`](#version) | 1 |  |
@@ -226,6 +247,20 @@ Elements acceptable within `<maintainer>`
 * Description: *not yet documented*
 * Contains: text
 
+### `<psr4>` {:#psr4}
+
+* Containing element: [`<classloader>`](#classloader)
+* Description: *not yet documented*
+* Contains: nothing &mdash; should be empty
+
+Attributes acceptable for `<psr4>`
+
+| Attribute | Contains |  Purpose |
+| -- | -- | -- |
+| `prefix` | text | *Not yet documented* |
+| `path` | text | *Not yet documented* |
+
+
 ### `<releaseDate>` {:#releaseDate}
 
 * Containing element: [`<extension>`](#extension)
@@ -237,6 +272,18 @@ Elements acceptable within `<maintainer>`
 * Containing element: [`<typeInfo>`](#typeInfo)
 * Description: *not yet documented*
 * Contains: text
+
+### `<requires>` {:#requires}
+
+* Containing element: [`<extension>`](#extension)
+* Description: Used to to specify other extension on which this extension is dependent
+* Contains: elements
+
+Elements acceptable within `<requires>`
+
+| Element | Acceptable instances | 
+| -- | -- |
+| [`<ext>`](#ext) | 1+ |
 
 ### `<signatureLabel>` {:#signatureLabel}
 

--- a/docs/extensions/info-xml.md
+++ b/docs/extensions/info-xml.md
@@ -1,4 +1,4 @@
-# Extension Reference
+# info.xml
 
 ## Introduction
 

--- a/docs/extensions/info-xml.md
+++ b/docs/extensions/info-xml.md
@@ -66,6 +66,18 @@ Here we describe all the elements acceptable within the XML file. They are prese
 * Description: *not yet documented*
 * Contains: text
 
+### `<civix>` {:#civix}
+
+* Containing element: [`<extension>`](#extension)
+* Description: Used to store settings which [civix](/extensions/civix.md) reads and writes 
+* Contains: elements
+
+Elements acceptable within `<civix>`
+
+| Element | Acceptable instances | 
+| -- | -- |
+| [`<namespace>`](#namespace) | 1 |
+
 ### `<comments>` {:#comments}
 
 * Containing element: [`<extension>`](#extension)
@@ -132,6 +144,7 @@ Elements acceptable within `<extension>`
 
 | Element | Acceptable instances | Acceptable<br>when |
 | -- | -- | -- |
+| [`<civix>`](#civix) | 0 or 1 |  |
 | [`<compatibility>`](#compatibility) | 1 |  |
 | [`<comments>`](#comments) | 0 or 1 |  |
 | [`<description>`](#description) | 1 |  |
@@ -193,6 +206,13 @@ Elements acceptable within `<maintainer>`
 * Containing element: [`<extension>`](#extension)
 * Description: Human-readable name of the extension. It can contain spaces
 * Contains: text
+
+### `<namespace>` {:#namespace}
+
+* Containing element: [`<civix>`](#civix)
+* Description: The PHP namespace that [civix](/extensions/civix.md) uses when generating code 
+* Contains: text
+* Example: `CRM/Volunteer`
 
 ### `<passwordLabel>` {:#passwordLabel}
 

--- a/docs/extensions/info-xml.md
+++ b/docs/extensions/info-xml.md
@@ -87,7 +87,7 @@ Elements acceptable within `<civix>`
 ### `<compatibility>` {:#compatibility}
 
 * Containing element: [`<extension>`](#extension)
-* Description: specifies the versions of CiviCRM which which this extension is compatible
+* Description: specifies the versions of CiviCRM with which this extension is compatible
 * Contains: elements
 
 Elements acceptable within `<compatibility>`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ pages:
   - Basics: extensions/index.md
   - civix: extensions/civix.md
   - Extension Structure: extensions/structure.md
+  - info.xml file: extensions/info-xml.md
   # Creating Pages: extensions/create-page.md
   # Storing Configuration: extensions/config.md
   # Storing Data: extensions/storing-data.md

--- a/redirects/wiki-crmdoc.txt
+++ b/redirects/wiki-crmdoc.txt
@@ -143,3 +143,4 @@ REST+interface api/interfaces#rest-interface
 AJAX+Interface api/interfaces#ajax-interface
 Smarty+API+interface api/interfaces#smarty-api-interface
 Cache+Reference framework/cache-reference
+Extension+Reference extensions/info-xml


### PR DESCRIPTION
Reviews welcome. Will merge in 5 days if no comments.

This page migration really ballooned into way bigger of a project than I wanted. I ended up researching quite a bit about [XSD](https://en.wikipedia.org/wiki/XML_Schema_(W3C)) and [RELAX NG](https://en.wikipedia.org/wiki/RELAX_NG) in hopes that I could generate some good-looking docs from an `.xsd` or `.rng` file. But unfortunately the available tools for turning schema definition into doc are not good. In the process of this research, however, I did learn a bit more about how people typically describe XML schemata. Even though this page was a lot of work to put together, I think this format is ultimately a bit superior to the [database schema definition](https://docs.civicrm.org/dev/en/latest/framework/schema-definition/) page. It is a bummer that the pages are in different formats. I wrestled with this a bit. Anyway, there's lots more I could say about all this, but like I said, I've already spent too much time on this one. Phew! 