### PR TITLE
Update hook_civicrm_caseSummary.md

### DIFF
--- a/docs/hooks/hook_civicrm_caseSummary.md
+++ b/docs/hooks/hook_civicrm_caseSummary.md
@@ -25,13 +25,18 @@ underneath the existing summary table.
      <?php
     function myModule_civicrm_caseSummary($caseID) {
         /* Quick way to test what some results look like.
-        return array('some_unique_id' => array( 'label' => ts('Some Date'),
-                                        'value' => '2009-02-11',
-                                       ),
-                     'some_other_id' => array( 'label' => ts('Some String'),
-                                        'value' => ts('Coconuts'),
-                                       ),
-                     );
+        return array(
+            array(
+                'some_unique_id' => array(
+                    'label' => ts('Some Date'),
+                    'value' => '2009-02-11',
+                 ),
+                'some_other_id' => array(
+                    'label' => ts('Some String'),
+                    'value' => ts('Coconuts'),
+                ),
+            ),
+        );
         */
 
         // More realistic example, but will return nothing unless you have these activities in your database.
@@ -83,13 +88,17 @@ underneath the existing summary table.
 
         $mcstat = CRM_Core_DAO::singleValueQuery( $sql, $params );
 
-        return array('modrtw' => array( 'label' => ts('Mod RTW:'),
-                                        'value' => $modrtw,
-                                       ),
-                     'mcstat' => array( 'label' => ts('Consent Status:'),
-                                        'value' => ts($mcstat),
-                                       ),
-                     );
+        return array(
+            array(
+                'modrtw' => array(
+                    'label' => ts('Mod RTW:'),
+                    'value' => $modrtw,
+                ),
+                'mcstat' => array( 'label' => ts('Consent Status:'),
+                    'value' => ts($mcstat),
+                ),
+            ),
+        );
 
     Put this in css/extras.css:
 


### PR DESCRIPTION
I was just trying this hook out in 4.7.22, the result pulls out the first element of the return and lists that on the case summary page. From the old docs, just gets the first key/val pair, then displays the first character of the label/value string.