### PR TITLE
hook_civicrm_angularModule - Add basic doc for `settings`

### DIFF
--- a/docs/hooks/hook_civicrm_angularModules.md
+++ b/docs/hooks/hook_civicrm_angularModules.md
@@ -23,6 +23,7 @@ Each item `angularModules`  may include these properties:
  * `js` (`array`): List of Javascript files. May use the wildcard (`*`). Relative to the extension.
  * `css` (`array`): List of CSS files. May use the wildcard (`*`). Relative to the extension.
  * `partials` (`array`): List of HTML folders. Relative to the extension.
+ * `settings` (`array`): Runtime data to export from PHP to JS. This is mapped to the JS global (Ex: `array("foo"=>"bar")`, which would  be available as `CRM.myModule.foo`.
  * `requires` (`array`): List of AngularJS modules required by this module. Default: `array()`. (`v4.7.21+`)
  * `basePages` (`array`): Uncondtionally load this module onto the given Angular pages. (`v4.7.21+`)
    * If omitted, the default is `array('civicrm/a')`. This provides backward compatibility with behavior since `v4.6+`.
@@ -47,5 +48,8 @@ Each item `angularModules`  may include these properties:
         'js' => array('js/part1.js', 'js/part2.js'),
         'css' => array('css/myAngularModule.css'),
         'partials' => array('partials/myBigAngularModule'),
+        'settings' => array(
+          'foo' => 'bar',
+        ),
       );
     }


### PR DESCRIPTION
This fills in a little info about an additional field named `settings`. 
It's not exactly as deep as "War & Peace", but it's about the same level as
similar docs.