### PR TITLE
Document civi-test-run script (take 2)

### DIFF
--- a/docs/testing/continuous-integration.md
+++ b/docs/testing/continuous-integration.md
@@ -35,5 +35,9 @@ codebase.
  
 Code-style is not checked on this build, but all upgrade and web tests are run.
 
+## Running the test suite locally
+
+You can use [civi-test-run](/tools/civi-test-run.md) locally to run a full standard CiviCRM Test suite.
+
 [jenkins-test-results]: https://test.civicrm.org/
 [testing-readme]: https://github.com/civicrm/civicrm-core/blob/master/tests/README.md

--- a/docs/testing/javascript.md
+++ b/docs/testing/javascript.md
@@ -14,11 +14,7 @@ $ cd /path/to/civicrm
 $ npm test
 ```
 
-You can also run the karama tests as they would be run by Jenkins using the `civi-test-run` command
-
-```bash
-$ civi-test-run "<buildname>" "<civicrm version>" "<junitdir>" "karma"
-```
+You can also run the karama tests as they would be run by [Jenkins](/testing/continuous-integration.md) using [civi-test-run](/tools/civi-test-run.md).
 
 [karma]: https://karma-runner.github.io/1.0/index.html
 [jasmine]: https://jasmine.github.io/2.1/introduction.html

--- a/docs/testing/javascript.md
+++ b/docs/testing/javascript.md
@@ -10,8 +10,14 @@ conventions using [karma] and [jasmine].
 ## Running Javascript Tests
 
 ```bash
-cd /path/to/civicrm
-npm test
+$ cd /path/to/civicrm
+$ npm test
+```
+
+You can also run the karama tests as they would be run by Jenkins using the `civi-test-run` command
+
+```bash
+$ civi-test-run "<buildname>" "<civicrm version>" "<junitdir>" "karma"
 ```
 
 [karma]: https://karma-runner.github.io/1.0/index.html

--- a/docs/testing/phpunit.md
+++ b/docs/testing/phpunit.md
@@ -52,18 +52,7 @@ $ env CIVICRM_UF=UnitTests phpunit4 ./tests/phpunit/api/v3/CaseTest.php --filter
     You can also specify tests in an environment variable `PHPUNIT_TESTS` (eg. `env PHPUNIT_TESTS="MyFirstTest::testFoo MySecondTest" phpunit EnvTests`
     Then run `phpunit4 ./tests/phpunit/EnvTests.php`.
 
-You can also optionally run a full standard CiviCRM Test suite by running `civi-test-run` as per example below
-
-```bash
-$ civi-test-run "<buildName>" "<civicrm version>" "<junit dir>" "<test-type>"
-```
-The test type is one of:
-
--  All: Run all standard CiviCRM Test Suites
--  phpunit-e2e - Run the E2E test suite
--  phpunit-civi - Run the Civi/ Test Suite
--  phpunit-api - Run the `api_v3` Test Suite
--  phpunit-crm - Run the `CRM` Test Suite
+You can also optionally use [civi-test-run](/tools/civi-test-run.md) to run a full standard CiviCRM Test suite.
 
 ## Writing Tests
 

--- a/docs/testing/phpunit.md
+++ b/docs/testing/phpunit.md
@@ -52,7 +52,7 @@ $ env CIVICRM_UF=UnitTests phpunit4 ./tests/phpunit/api/v3/CaseTest.php --filter
     You can also specify tests in an environment variable `PHPUNIT_TESTS` (eg. `env PHPUNIT_TESTS="MyFirstTest::testFoo MySecondTest" phpunit EnvTests`
     Then run `phpunit4 ./tests/phpunit/EnvTests.php`.
 
-You can also optionallly run a full standard CiviCRM Test suite by running `civi-test-run` as per example below
+You can also optionally run a full standard CiviCRM Test suite by running `civi-test-run` as per example below
 
 ```bash
 $ civi-test-run "<buildName>" "<civicrm version>" "<junit dir>" "<test-type>"

--- a/docs/testing/phpunit.md
+++ b/docs/testing/phpunit.md
@@ -52,6 +52,19 @@ $ env CIVICRM_UF=UnitTests phpunit4 ./tests/phpunit/api/v3/CaseTest.php --filter
     You can also specify tests in an environment variable `PHPUNIT_TESTS` (eg. `env PHPUNIT_TESTS="MyFirstTest::testFoo MySecondTest" phpunit EnvTests`
     Then run `phpunit4 ./tests/phpunit/EnvTests.php`.
 
+You can also optionallly run a full standard CiviCRM Test suite by running `civi-test-run` as per example below
+
+```bash
+$ civi-test-run "<buildName>" "<civicrm version>" "<junit dir>" "<test-type>"
+```
+The test type is one of:
+
+-  All: Run all standard CiviCRM Test Suites
+-  phpunit-e2e - Run the E2E test suite
+-  phpunit-civi - Run the Civi/ Test Suite
+-  phpunit-api - Run the `api_v3` Test Suite
+-  phpunit-crm - Run the `CRM` Test Suite
+
 ## Writing Tests
 
 When writing Core tests you should extend from `\CiviUnitTestCase`.

--- a/docs/testing/upgrades.md
+++ b/docs/testing/upgrades.md
@@ -8,3 +8,10 @@ CMS-integration.
 
 Upgrade tests are run daily on the Jenkins [continuous integration](/testing/continuous-integration.md) server.
 
+## Local Upgrade Testing
+
+Locally you can run the same upgrade tests as Jenkins would using `civi-test-run` as per the following example
+
+```bash
+$ civi-test-run "<civibuildname>" "<civiversion>" "<junitdir>" "upgrade"
+```

--- a/docs/testing/upgrades.md
+++ b/docs/testing/upgrades.md
@@ -8,10 +8,4 @@ CMS-integration.
 
 Upgrade tests are run daily on the Jenkins [continuous integration](/testing/continuous-integration.md) server.
 
-## Local Upgrade Testing
-
-Locally you can run the same upgrade tests as Jenkins would using `civi-test-run` as per the following example
-
-```bash
-$ civi-test-run "<civibuildname>" "<civiversion>" "<junitdir>" "upgrade"
-```
+Locally you can use [civi-test-run](/tools/civi-test-run.md) to run the same upgrade tests as Jenkins would.

--- a/docs/tools/civi-test-run.md
+++ b/docs/tools/civi-test-run.md
@@ -1,6 +1,6 @@
 # civi-test-run
 
-`civi-test-run` is a script which runs one or more test suites locally.
+`civi-test-run` is a script which runs one or more test suites locally. It is compatible with `civibuild`-based deployments.
 
 ## Installation
 
@@ -19,8 +19,9 @@ $ civi-test-run
 The test type is one of:
 
 -  `all` - Run all standard CiviCRM Test Suites
--  `phpunit-e2e` - Run the E2E test suite
--  `phpunit-civi` - Run the `Civi/` Test Suite
+-  `karma` - Run the KarmaJS test suite
 -  `phpunit-api` - Run the `api_v3` Test Suite
+-  `phpunit-civi` - Run the `Civi/` Test Suite
 -  `phpunit-crm` - Run the `CRM` Test Suite
-
+-  `phpunit-e2e` - Run the E2E test suite
+-  `upgrade` - Run the upgrade test suite

--- a/docs/tools/civi-test-run.md
+++ b/docs/tools/civi-test-run.md
@@ -1,0 +1,26 @@
+# civi-test-run
+
+`civi-test-run` is a script which runs one or more test suites locally.
+
+## Installation
+
+`civi-test-run` is included within [buildkit](/tools/buildkit.md).
+
+## Usage
+
+Run without arguments to see the exact usage:
+
+```bash
+$ civi-test-run
+```
+
+## Test types
+
+The test type is one of:
+
+-  `all` - Run all standard CiviCRM Test Suites
+-  `phpunit-e2e` - Run the E2E test suite
+-  `phpunit-civi` - Run the `Civi/` Test Suite
+-  `phpunit-api` - Run the `api_v3` Test Suite
+-  `phpunit-crm` - Run the `CRM` Test Suite
+

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -34,6 +34,9 @@ When you install [buildkit](/tools/buildkit.md) you'll get all these tools.
     * *repository: [within civicrm-buildkit](https://github.com/civicrm/civicrm-buildkit/blob/master/bin/civihydra)*
 * `civicrm-upgrade-test` - Scripts and data files for testing upgrades
     * *[documentation& repository](https://github.com/civicrm/civicrm-upgrade-test)*
+* `civi-test-run` - Run one or more test suites
+    * *[documentation](/tools/civi-test-run.md)*
+    * *repository: [within civicrm-buildkit](https://github.com/civicrm/civicrm-buildkit/blob/master/bin/civi-test-run)*
 * Coder - Configure phpcs for CiviCRM's [coding standards](/standards/php.md)
     * *[documentation & repository](https://github.com/civicrm/coder)*
     * *(Derived from [Drupal's coder project](https://www.drupal.org/project/coder))*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ pages:
   - civibuild: tools/civibuild.md
   - cividist: tools/cividist.md
   - civilint: tools/civilint.md
+  - civi-test-run: tools/civi-test-run.md
   - Issue Tracking: tools/issue-tracking.md
   - Git, GitHub, &amp; GitLab: tools/git.md
   - Jenkins: tools/jenkins.md


### PR DESCRIPTION
This builds on top of #325 and is intended to replace it. 

In #325 Seamus added docs for a new script, `civi-test-run`. 

This PR is different from #325 in the following ways: 

* Use a separate page for `civi-test-run` in the "Tools" chapter
* Point readers to this page so that we can avoid duplicating efforts to describe `civi-test-run`
* Also mention `civi-test-run` in the *list* of all tools
* Don't describe the script's usage. Instead instruct readers to run the script to observe its usage via the command line. (This is to address [comments](https://github.com/civicrm/civicrm-dev-docs/pull/325#issuecomment-328699764) from Tim about how the signature is likely to change in the future)
