### PR TITLE
Issue # 397 Replace 'Wordpress' with 'WordPress' to use correct camel casing acco…

### DIFF
--- a/docs/basics/planning.md
+++ b/docs/basics/planning.md
@@ -46,7 +46,7 @@ Make sure to check [the contribution guidelines](https://github.com/civicrm/civi
 
 **From the outset, [automate testing](/testing/setup.md)**. In the current climate of rapid evolution of not just CiviCRM, but also it's myriad of dependancies, automated testing of PHP code with `phpunit` and javascript with tools like `karma` and `jasmine` is essential. Start all your work by considering how you will provide automated testing for it. Starting with the buildkit will make this much simpler for you to set up. Getting started with unit-testing may seem daunting and onerous when you start, but you will soon come to love the freedom it gives you. If you are unsure how to proceed with testing ask the [community](/basics/community.md).
 
-**Create a native [extension](/extensions/index.md)**. If you have new functionality to add to CiviCRM, it probably belongs in an extension.  "Native" extensions will install into all CiviCRM sites regardless of the  underlying CMS used (Drupal or Wordpress), making it easy to share your extension with the CiviCRM community.
+**Create a native [extension](/extensions/index.md)**. If you have new functionality to add to CiviCRM, it probably belongs in an extension.  "Native" extensions will install into all CiviCRM sites regardless of the  underlying CMS used (Drupal or WordPress), making it easy to share your extension with the CiviCRM community.
 
 **Use the [API](/api/index.md) and [hooks](/hooks/index.md)** to access and manage CiviCRM data in any patch, native extension, CMS module, or external program that you develop. The API will function as expected with every new release and backwards compatibility of the API is maintained for several versions of CiviCRM. 
 

--- a/docs/basics/skills.md
+++ b/docs/basics/skills.md
@@ -32,9 +32,9 @@ other technologies (such as PHP and Git, which are not CiviCRM-specific) are out
     -   [CSS tutorial](http://www.w3schools.com/css/default.asp)
     -   [Can I use](http://caniuse.com/) - good for seeing which web browsers have implemented certain CSS features.
     -   [Comparison of layout engines](https://en.wikipedia.org/wiki/Comparison_of_layout_engines_\(Cascading_Style_Sheets\)) another helpful comparison of the differences between web browsers.
--   **Drupal / Wordpress / Joomla!** - CiviCRM must be installed within one of these content management systems, and learning more about the underlying CMS will aid CiviCRM development. Drupal is favored by most CiviCRM developers and CiviCRM actually borrows many development practices from the project, so learning Drupal is a good place to start if you are unsure. That said, Wordpress is the most popular CMS and it has been so for several years now. 
+-   **Drupal / WordPress / Joomla!** - CiviCRM must be installed within one of these content management systems, and learning more about the underlying CMS will aid CiviCRM development. Drupal is favored by most CiviCRM developers and CiviCRM actually borrows many development practices from the project, so learning Drupal is a good place to start if you are unsure. That said, WordPress is the most popular CMS and it has been so for several years now. 
     -   [Drupal documentation](https://www.drupal.org/docs/)
-    -   [Wordpress documentation](https://codex.wordpress.org/Main_Page)
+    -   [WordPress documentation](https://codex.wordpress.org/Main_Page)
     -   [Joomla documentation](https://docs.joomla.org/)
 -   **SQL / MySQL** - "SQL" is a standardized language used by many different types of database management systems to manipulate data in the database. "MySQL" is one specific database management system which, by default, CiviCRM uses to store all its data. The query syntax that MySQL uses conforms [almost](http://troels.arvin.dk/db/rdbms/) entirely to the SQL standard, so learning SQL is basically synonymous to learning MySQL.
     -   [SQL tutorial](http://www.w3schools.com/sql/default.asp)

--- a/docs/framework/region.md
+++ b/docs/framework/region.md
@@ -163,7 +163,7 @@ The system plugin (plgSystemCivicrmsys) uses [onBeforeCompileHead](http://docs.j
 
 At time of writing, tags are outputted as plain HTML markup.
 
-#### Wordpress
+#### WordPress
 
 The `civicrm_wp_main()` registers a callback for the [wp_head](http://codex.wordpress.org/Plugin_API/Action_Reference/wp_head) action.
 

--- a/docs/hooks/setup/wordpress.md
+++ b/docs/hooks/setup/wordpress.md
@@ -53,7 +53,7 @@ add_filter( 'civicrm_pre', array( $this, 'my_callback_method', 10, 4 )
 ```
 
 For more details (as well as the exceptions to this rule) see the 
-[blog post][civi-wp-blog] on CiviCRM in Wordpress.
+[blog post][civi-wp-blog] on CiviCRM in WordPress.
 
 ## Legacy Hooks
 

--- a/docs/standards/javascript.md
+++ b/docs/standards/javascript.md
@@ -79,7 +79,7 @@ You can also specify other regions of the page to place the script in (the most 
 
 ## Using CiviCRM Javascript in non CiviCRM pages
 
-If you are working outside the context of CiviCRM pages (e.g. on a Drupal page, Wordpress widget, Joomla page, etc) you need to explicitly tell CiviCRM to load its javascript in to the page header. You can add your own scripts as well.
+If you are working outside the context of CiviCRM pages (e.g. on a Drupal page, WordPress widget, Joomla page, etc) you need to explicitly tell CiviCRM to load its javascript in to the page header. You can add your own scripts as well.
 
 ```php
 civicrm_initialize();

--- a/docs/tools/cividist.md
+++ b/docs/tools/cividist.md
@@ -30,7 +30,7 @@ git remote add myfork https://github.com/myfork/civicrm-packages.git
 cd build/dist/src/joomla
 git remote add myfork https://github.com/myfork/civicrm-joomla.git
 
-cd build/dist/src/Wordpress
+cd build/dist/src/WordPress
 git remote add myfork https://github.com/myfork/civicrm-wordpress.git
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,7 @@ pages:
     - Hooks with Symfony: hooks/setup/symfony.md
     - Hooks with Joomla: hooks/setup/joomla.md
     - Hooks with Drupal: hooks/setup/drupal.md
-    - Hooks with Wordpress: hooks/setup/wordpress.md
+    - Hooks with WordPress: hooks/setup/wordpress.md
   - Batch Hooks:
     - hook_civicrm_batchItems: hooks/hook_civicrm_batchItems.md
     - hook_civicrm_batchQuery: hooks/hook_civicrm_batchQuery.md


### PR DESCRIPTION
…rding to the WordPress Wordmark and Trademark  https://github.com/civicrm/civicrm-dev-docs/issues/397