### PR TITLE
change path in Entity creation w/flow

### DIFF
--- a/docs/extensions/civix.md
+++ b/docs/extensions/civix.md
@@ -158,7 +158,7 @@ If you want your extension to store data in the database, then you will need to 
 
         * *Prior to CiviCRM 4.7.12, you would instead run `php ./GenCode.php` from the `xml` folder.*
 
-    1. Copy the DAO file `<civiroot>/CRM/MyEntity/DAO/MyEntity.php` into your extension at `CRM/MyEntity/DAO/MyEntity.php`.
+    1. Copy the DAO file `<civiroot>/CRM/MyExtension/DAO/MyEntity.php` into your extension at `CRM/MyExtension/DAO/MyEntity.php`.
 
     1. Within your extension, create an `sql` directory and create two empty files within it: `auto_install.sql` and `auto_uninstall.sql`.
 


### PR DESCRIPTION
I'm not sure if this has only come about because of my ineptitude (i.e. whether an Entity would always have the same name as the extension), but I found that I couldn't find the files referred to because my Entity and my Extension had different names.

Would that be bad practice on my part? (it would be good to know as I'm very new to coding)

Either way, I think this may be more accurate... whether I'm right or not is up to you.

Cheers,
M.