### PR TITLE
documentation/style-guide.md - Mention bash portability tip

### DIFF
--- a/docs/documentation/style-guide.md
+++ b/docs/documentation/style-guide.md
@@ -245,3 +245,8 @@ yourusername      git@github.com:yourusername/civicrm-core.git (push)
 ```
 
 Authors should also not put any comments within the examples themselves, whereas any comments should go outside of the code block in regular paragraphs. Where possible each command should be its own comment block. When it is crucial for the user to understand the directory in which to run the command, include a separate code block before hand with a `cd` command.
+
+!!! tip "Write portable shell commands"
+
+    Most system administrators use `bash` as their interactive command-line, but some administrators customize their systems to use `csh`, `zsh`, or similar. 
+    These systems are usually very similar -- but may differ if there are complex conditionals, job-controls, etc. See [bash-hackers.org](http://wiki.bash-hackers.org/scripting/nonportable) for tips on writing portable shell commands.


### PR DESCRIPTION
If a reader has customized their interactive shell, their system could have
small discrepancies in shell notation.  It shouldn't matter 95% of the time,
and it's not critical to support those folks perfectly.  But it is nice.  So
let's just share the link to heighten awareness.

(Example: I usually do `export VAR=value`...  but in future docs, I'll try
to use `VAR=value; export VAR`.)

This is following-up on some comments from @ginkgomzd who found the
`bash-hackers.org` site and shared it on https://github.com/civicrm/civicrm-buildkit/pull/365