### PR TITLE
mkdocs.yml - Simplify menu headings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -196,7 +196,7 @@ pages:
   - Permissions: security/permissions.md
   - Access Control: security/access.md
   - Reporting Vulnerabilities: security/reporting.md
-- Framework Reference:
+- Framework:
   - AJAX Pages and Forms Reference: framework/ajax.md
   - AngularJS:
     - AngularJS Intro: framework/angular/index.md
@@ -234,12 +234,12 @@ pages:
     - Extending Smarty: framework/templates/extending-smarty.md
   - UI Reference: framework/ui.md
   - Upgrade Reference: framework/upgrade.md
-- Development Standards:
-  - Coding Standards: standards/index.md
-  - PHP Standards: standards/php.md
-  - Javascript Reference: standards/javascript.md
-  - Database Standards: standards/database.md
-  - Review Standards: standards/review.md
+- Standards:
+  - General: standards/index.md
+  - PHP: standards/php.md
+  - Javascript: standards/javascript.md
+  - Database: standards/database.md
+  - Review: standards/review.md
 - Documentation:
   - Writing Documentation: documentation/index.md
   - Documenting Extensions: documentation/extensions.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -235,11 +235,11 @@ pages:
   - UI Reference: framework/ui.md
   - Upgrade Reference: framework/upgrade.md
 - Standards:
-  - General: standards/index.md
-  - PHP: standards/php.md
-  - Javascript: standards/javascript.md
-  - Database: standards/database.md
-  - Review: standards/review.md
+  - Coding Standards: standards/index.md
+  - PHP Standards: standards/php.md
+  - Javascript Standards: standards/javascript.md
+  - Database Standards: standards/database.md
+  - Review Standards: standards/review.md
 - Documentation:
   - Writing Documentation: documentation/index.md
   - Documenting Extensions: documentation/extensions.md


### PR DESCRIPTION
When scanning the navbar, there are several words which (IMHO) aren't adding
much value.  This simplifies and should make it easier to navigate.

## Before

<img width="1214" alt="screen shot 2017-10-24 at 3 50 57 pm" src="https://user-images.githubusercontent.com/1336047/31972056-93d1e2d8-b8d3-11e7-89bc-50e53fd8ca17.png">

## After

<img width="1213" alt="screen shot 2017-10-24 at 3 51 11 pm" src="https://user-images.githubusercontent.com/1336047/31972057-94291b52-b8d3-11e7-88ef-214900a76392.png">
