### PR TITLE
Fix Typo

### DIFF
--- a/docs/api/usage.md
+++ b/docs/api/usage.md
@@ -221,7 +221,7 @@ cv api contact.get first_name=Alice last_name=Roberts
 
 ## API Security
 
-API has security mesasures built in depending on the way the API is called that can also be turned off or on. API Permissions are also able to be altered via hook. More information on API Security can be found in the [Security Doucmentation](/security/permissions.md).
+API has security mesasures built in depending on the way the API is called that can also be turned off or on. API Permissions are also able to be altered via hook. More information on API Security can be found in the [Security Documentation](/security/permissions.md).
 
 ## API Lookups by Username
 


### PR DESCRIPTION
"Security Doucmentation" --> "Security Documentation" -- as pointed out by agileware__francis