### PR TITLE
Update hook_civicrm_container.md

### DIFF
--- a/docs/hooks/hook_civicrm_container.md
+++ b/docs/hooks/hook_civicrm_container.md
@@ -16,7 +16,7 @@ This hook is available in CiviCRM 4.7+.
 
 ## Definition
 
-    hook_civicrm_container(\Symfony\Component\DependencyInjection\ContainerBuilder $container)
+    hook_civicrm_container($container)
 
 ## Parameters
 


### PR DESCRIPTION
The civicrm core container does not extend the symfony ContainerBuilder class. There for remove it here otherwise the hook is not going to work.