### PR TITLE
Fix $this-> to self:: for an static property

### DIFF
--- a/docs/extensions/payment-processors/create.md
+++ b/docs/extensions/payment-processors/create.md
@@ -113,7 +113,7 @@ class edu_ucmerced_payment_ucmpaymentcollection extends CRM_Core_Payment {
    * @return void
    */
   function __construct( $mode, &$paymentProcessor ) {
-    $this->_mode             = $mode;
+    self::$_mode             = $mode;
     $this->_paymentProcessor = $paymentProcessor;
     $this->_processorName    = ts('UC Merced Payment Collection');
   }


### PR DESCRIPTION
This will prevent an error like the described if a person is following this tutorial.

```
Notice: Accessing static property CRM_Core_Payment_CUSTOM::$_mode as non static in CRM_Core_Payment_CUSTOM->__construct() 
```

Where `CUSTOM` is a placeholder for the procesor the dev is making.