### PR TITLE
Add docs for hook_civicrm_alterLocationMergeData

### DIFF
--- a/docs/hooks/hook_civicrm_alterLocationMergeData.md
+++ b/docs/hooks/hook_civicrm_alterLocationMergeData.md
@@ -1,0 +1,44 @@
+# hook_civicrm_alterLocationMergeData
+
+## Summary
+
+This hook allows you to alter the location information that will be moved from
+the duplicate contact to the master contact.
+
+## Availability
+
+This hook was first available in CiviCRM 4.7.10.
+
+## Definition
+
+```php
+hook_civicrm_alterLocationMergeData(&$blocksDAO, $mainId, $otherId, $migrationInfo)
+```
+
+## Parameters
+
+   * array $blocksDAO: Array of location DAO to be saved. These are arrays in 2 keys 'update' & 'delete'.
+   * int $mainId: Contact ID of the contact that survives the merge.
+   * int $otherId: Contact ID of the contact that will be absorbed and deleted.
+   * array $migrationInfo: Calculated migration info.
+
+## Details
+
+The $blocksDAO contains a list of 'location blocks' (eg: emails, phones,
+addresses) which will be updated or deleted as part of the merge. This is
+formatted like:
+
+````
+[
+  email
+    delete
+      id => object
+    update
+      id => object
+  address
+    delete
+      id => object
+    update
+      id => object
+]
+````

--- a/docs/hooks/hook_civicrm_alterLocationMergeData.md
+++ b/docs/hooks/hook_civicrm_alterLocationMergeData.md
@@ -28,7 +28,7 @@ The $blocksDAO contains a list of 'location blocks' (eg: emails, phones,
 addresses) which will be updated or deleted as part of the merge. This is
 formatted like:
 
-````
+```php
 [
   email
     delete
@@ -41,4 +41,4 @@ formatted like:
     update
       id => object
 ]
-````
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ pages:
     - hook_civicrm_custom: hooks/hook_civicrm_custom.md
     - hook_civicrm_managed: hooks/hook_civicrm_managed.md
     - hook_civicrm_merge: hooks/hook_civicrm_merge.md
+    - hook_civicrm_alterLocationMergeData: hooks/hook_civicrm_alterLocationMergeData.md
     - hook_civicrm_post: hooks/hook_civicrm_post.md
     - hook_civicrm_postSave_table_name: hooks/hook_civicrm_postSave_table_name.md
     - hook_civicrm_pre: hooks/hook_civicrm_pre.md

--- a/redirects/wiki-crmdoc.txt
+++ b/redirects/wiki-crmdoc.txt
@@ -11,6 +11,7 @@ hook_civicrm_copy hooks/hook_civicrm_copy
 hook_civicrm_custom hooks/hook_civicrm_custom
 hook_civicrm_managed hooks/hook_civicrm_managed
 hook_civicrm_merge hooks/hook_civicrm_merge
+hook_civicrm_alterLocationMergeData hooks/hook_civicrm_alterLocationMergeData
 hook_civicrm_post hooks/hook_civicrm_post
 hook_civicrm_pre hooks/hook_civicrm_pre
 hook_civicrm_trigger_info hooks/hook_civicrm_triggerInfo


### PR DESCRIPTION
There wasn't any documentation for hook_civicrm_alterLocationMergeData, so I thought we should create something! It was introduced in 4.7.10.

@eileenmcnaughton is there anything you think we should add to this?

It would be good to get something basic up, which we can embellish later if needed.

I'm not sure if I've edited this in all the right places, let me know if I need to make any changes.