### PR TITLE
Fix typo in hook_civicrm_links 

### DIFF
--- a/docs/hooks/hook_civicrm_links.md
+++ b/docs/hooks/hook_civicrm_links.md
@@ -12,6 +12,10 @@ dropdown, and the Actions dropdown at the top of a contact record.
 !!! tip
     Remember to use the string processing functions of your host framework ( `ts()` for CiviCRM extensions, `t()` for Drupal modules, etc).
 
+!!! warning
+    The operation `create.new.shorcuts` is now deprecated and has been replaced with the correctly spelled `create.new.shortcuts`.
+
+
 ## Definition
 
 ```php
@@ -25,10 +29,10 @@ hook_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values)
     `pdfFormat.manage.action`
 
 -   string `$objectName` - the entity the links relate to (or `NULL` if `$op` is
-    `create.new.shorcuts`)
+    `create.new.shortcuts`)
 
 -   int `$objectId` - the CiviCRM internal ID of the entity (or `NULL` if `$op`
-    is `create.new.shorcuts`)
+    is `create.new.shortcuts`)
 
 -   array `$links` - the links to modify in place
 
@@ -100,7 +104,7 @@ function MODULENAME_civicrm_links($op, $objectName, $objectId, &$links, &$mask, 
           $values['thingId'] = 'mything';
           break;
 
-        case 'create.new.shorcuts':
+        case 'create.new.shortcuts':
           // add link to create new profile
           $links[] = array(
             'url' => '/civicrm/admin/uf/group?action=add&reset=1',


### PR DESCRIPTION
The code that adds a hook to enable a link to be added to a block has a typo. It says 'shorcuts' rather than 'shortcuts'.

I have corrected this in the code - see https://github.com/civicrm/civicrm-core/pull/12913 - the documentation will need to be updated to reflect this change.
