### PR TITLE
Correct function name

### DIFF
--- a/docs/hooks/hook_civicrm_navigationMenu.md
+++ b/docs/hooks/hook_civicrm_navigationMenu.md
@@ -83,7 +83,7 @@ function _getMenuKeyMax($menuArray) {
 function civicrm_civicrm_navigationMenu(&$params) {
 
   //  Get the maximum key of $params
-  $maxKey = getMenuKeyMax($params);
+  $maxKey = _getMenuKeyMax($params);
 
   $params[$maxKey+1] = array(
     'attributes' => array(


### PR DESCRIPTION
I believe the getMenuKeyMax function is missing it's underscore inside the hook example.