### PR TITLE
don't include deprecated attribute in example

### DIFF
--- a/docs/framework/setting.md
+++ b/docs/framework/setting.md
@@ -35,7 +35,6 @@ Each file consists of a php snippet which returns an array. Array keys are strin
 
 ```php
   'remote_profile_submissions' => array(
-    'group_name' => 'domain',
     'name' => 'remote_profile_submissions',
     'type' => 'Boolean',
     'quick_form_type' => 'YesNo',


### PR DESCRIPTION
Many users will simply copy and paste the example settings file. However, this example contains an attribute that is deprecated.