### PR TITLE
Docs make it clear that clear is the preferred method

### DIFF
--- a/docs/framework/cache.md
+++ b/docs/framework/cache.md
@@ -29,7 +29,7 @@ The `CRM_Utils_Cache_Interface` class lays out the methods for saving and retrie
 * Flush the entire cache
 
     ```php
-    Civi::cache()->flush();
+    Civi::cache()->clear();
     ```
 
 !!! tip "PSR-16 Compliance (v5.4+)"


### PR DESCRIPTION
Changing flush to clear as the preferred method. I think when it was added there was an assumption devs would be developing against < 5.4 so it made sense to give primacy to flush but times have changed

@totten