### PR TITLE
Add Docs on new theme hooks

### DIFF
--- a/docs/hooks/hook_civicrm_activeThemes.md
+++ b/docs/hooks/hook_civicrm_activeThemes.md
@@ -1,0 +1,39 @@
+# hook_civicrm_activeTheme
+
+## Summary
+
+The activeTheme hook determines which theme is active.
+
+## Definition
+
+    hook_civicrm_activeTheme( &$theme, $context)
+
+## Parameters
+
+   - parameter string $theme
+      The identifier for the theme. Alterable.
+      Ex: 'greenwich'.
+   - parameter array $context
+      Information about the current page-request. Includes some mix of:
+      - page: the relative path of the current Civi page (Ex: 'civicrm/dashboard').
+      - themes: an instance of the Civi\Core\Themes service.
+
+## Returns
+
+-   null
+
+## Availability
+
+-   This hook was first available in CiviCRM 5.16
+
+## Example
+
+```php
+     /*
+     * Set which theme is active. 
+     */
+
+    function civitest_civicrm_activeTheme( &$theme, $context ) {
+      $theme = 'civielection';
+    }
+```

--- a/docs/hooks/hook_civicrm_themes.md
+++ b/docs/hooks/hook_civicrm_themes.md
@@ -46,19 +46,32 @@ This Hook is called when building a list of available themes for use within Civi
      /*
      * A theme is a set of CSS files which are loaded on CiviCRM pages.
      */
-
     function civitest_civicrm_themes( &$themes ) {
       $themes['civielection'] = [
-        'name' => 'civielection',
         'title' => 'civielection theme',
         'ext' => 'au.org.greens.civielection',
-        'prefix' => NULL,
+      ];
+    }
+```
+
+a more detailed example
+
+```php
+     /*
+     * A theme is a set of CSS files which are loaded on CiviCRM pages.
+     */
+    function civitest_civicrm_themes( &$themes ) {
+      $themes['civielection'] = [
+        'title' => 'civielection theme',
+        'ext' => 'au.org.greens.civielection',
+        'name' => 'civielection',
         'url_callback' => '\\Civi\\Core\\Themes\\Resolvers::simple',
         'search_order' => [
           0 => 'civielection',
-          1 => '_fallback_',
+          1 => Civi\Core\Themes::FALLBACK,
         ],
-        'excludes' => [],
+        'prefix' => 'election',
+        'excludes' => ['bootstrap.css'],
       ];
     }
 ```

--- a/docs/hooks/hook_civicrm_themes.md
+++ b/docs/hooks/hook_civicrm_themes.md
@@ -1,0 +1,63 @@
+# hook_civicrm_import
+
+## Summary
+
+This Hook is called when building a list of available themes for use within CiviCRM.
+
+## Definition
+
+    hook_civicrm_themes( &$themes )
+
+## Parameters
+
+-  array  $themes - array of theme information 
+    - ext: string (required)
+      The full name of the extension which defines the theme.
+      Ex: "org.civicrm.themes.greenwich".
+    - title: string (required)
+      Visible title.
+    - help: string (optional)
+      Description of the theme's appearance.
+    - url_callback: mixed (optional)
+       A function ($themes, $themeKey, $cssExt, $cssFile) which returns the URL(s) for a CSS resource.
+       Returns either an array of URLs or PASSTHRU.
+       Ex: \Civi\Core\Themes\Resolvers::simple (default)
+       Ex: \Civi\Core\Themes\Resolvers::none
+    - prefix: string (optional)
+      A prefix within the extension folder to prepend to the file name.
+    - search_order: array (optional)
+      A list of themes to search.
+      Generally, the last theme should be "*fallback*" (Civi\Core\Themes::FALLBACK).
+    - excludes: array (optional)
+      A list of files (eg "civicrm:css/bootstrap.css" or "$ext:$file") which should never
+      be returned (they are excluded from display).     - object being imported (for now Contact
+
+## Returns
+
+-   null
+
+## Availability
+
+-   This hook was first available in CiviCRM 5.16
+
+## Example
+
+```php
+     /*
+     * A theme is a set of CSS files which are loaded on CiviCRM pages.
+     */
+
+    function civitest_civicrm_themes( &$themes ) {
+      $themes[] = [
+        'name' => 'civielection',
+        'title' => 'civielection theme',
+        'prefix' => NULL,
+        'url_callback' => '\\Civi\\Core\\Themes\\Resolvers::simple',
+        'search_order' => [
+          0 => 'civielection',
+          1 => '_fallback_',
+        ],
+        'excludes' => [],
+      ];
+    }
+```

--- a/docs/hooks/hook_civicrm_themes.md
+++ b/docs/hooks/hook_civicrm_themes.md
@@ -1,8 +1,8 @@
-# hook_civicrm_import
+# hook_civicrm_themes
 
 ## Summary
 
-This Hook is called when building a list of available themes for use within CiviCRM.
+This hook is called when building a list of available themes for use within CiviCRM.
 
 ## Definition
 
@@ -42,6 +42,8 @@ This Hook is called when building a list of available themes for use within Civi
 
 ## Example
 
+A minimal example:
+
 ```php
      /*
      * A theme is a set of CSS files which are loaded on CiviCRM pages.
@@ -54,7 +56,7 @@ This Hook is called when building a list of available themes for use within Civi
     }
 ```
 
-a more detailed example
+A more detailed example
 
 ```php
      /*

--- a/docs/hooks/hook_civicrm_themes.md
+++ b/docs/hooks/hook_civicrm_themes.md
@@ -48,9 +48,10 @@ This Hook is called when building a list of available themes for use within Civi
      */
 
     function civitest_civicrm_themes( &$themes ) {
-      $themes[] = [
+      $themes['civielection'] = [
         'name' => 'civielection',
         'title' => 'civielection theme',
+        'ext' => 'au.org.greens.civielection',
         'prefix' => NULL,
         'url_callback' => '\\Civi\\Core\\Themes\\Resolvers::simple',
         'search_order' => [

--- a/docs/hooks/list.md
+++ b/docs/hooks/list.md
@@ -68,6 +68,7 @@ This is an overview list of all available hooks, listed by category.
 
 ## GUI Hooks
 
+* **[hook_civicrm_activeThemes](/hooks/hook_civicrm_activeThemes.md)** - The activeTheme hook determines which theme is active.
 * **[hook_civicrm_alterEntityRefParams](/hooks/hook_civicrm_alterEntityRefParams.md)** - called when an `entityRef` field is rendered in a form, which allows you to modify the parameters used to fetch options for this kind of field.
 * **[hook_civicrm_alterMenu](/hooks/hook_civicrm_alterMenu.md)** - called when building CiviCRM's list of HTTP routes and should be used when you want to register custom paths or URLS.
 * **[hook_civicrm_buildAmount](/hooks/hook_civicrm_buildAmount.md)** - called when building the amount structure for a Contribution or Event Page, allowing you to modify the set of radio buttons representing amounts for contribution levels and event registration fees.
@@ -84,6 +85,7 @@ This is an overview list of all available hooks, listed by category.
 * **[hook_civicrm_searchTasks](/hooks/hook_civicrm_searchTasks.md)** - called to display the list of actions allowed after doing a search, allowing you to inject additional actions or to remove existing actions.
 * **[hook_civicrm_summary](/hooks/hook_civicrm_summary.md)** - called when the contact summary is rendered, allowing you to modify the summary with your own content.
 * **[hook_civicrm_summaryActions](/hooks/hook_civicrm_summaryActions.md)** - allows you to customize the context menu actions on the Contact Summary Page.
+* **[hook_civicrm_themes](/hooks/hook_civicrm_themes.md)** - This Hook is called when building a list of available themes for use within CiviCRM.
 * **[<del>hook_civicrm_tabs</del>](/hooks/hook_civicrm_tabs.md)** - deprecated in 4.7 in favor of [hook_civicrm_tabset](/hooks/hook_civicrm_tabset.md).
 * **[hook_civicrm_tabset](/hooks/hook_civicrm_tabset.md)** - called when composing the tabs interface used for contacts, contributions and events.
 * **[hook_civicrm_xmlMenu](/hooks/hook_civicrm_xmlMenu.md)** - called when building CiviCRM's menu structure, which is used to render urls in CiviCRM.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ pages:
     - <del>hook_civicrm_validate</del>: hooks/hook_civicrm_validate.md
     - hook_civicrm_validateForm: hooks/hook_civicrm_validateForm.md
   - GUI Hooks:
+    - hook_civicrm_activeThemes: hooks/hook_civicrm_activeThemes.md
     - hook_civicrm_alterEntityRefParams: hooks/hook_civicrm_alterEntityRefParams.md
     - hook_civicrm_alterMenu: hooks/hook_civicrm_alterMenu.md
     - hook_civicrm_buildAmount: hooks/hook_civicrm_buildAmount.md
@@ -123,6 +124,7 @@ pages:
     - hook_civicrm_searchTasks: hooks/hook_civicrm_searchTasks.md
     - hook_civicrm_summary: hooks/hook_civicrm_summary.md
     - hook_civicrm_summaryActions: hooks/hook_civicrm_summaryActions.md
+    - hook_civicrm_themes: hooks/hook_civicrm_themes.md
     - <del>hook_civicrm_tabs</del>: hooks/hook_civicrm_tabs.md
     - hook_civicrm_tabset: hooks/hook_civicrm_tabset.md
     - hook_civicrm_xmlMenu: hooks/hook_civicrm_xmlMenu.md


### PR DESCRIPTION
While we merged the themeing stub there was no docs on the actual hooks associated this updates it