### PR TITLE
Add link to more info about the Civi:: facade

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -64,3 +64,5 @@ Fully supported methods are:
 * `Civi::$statics`
 * [`Civi::settings`](/framework/setting.md)
 * Internal Symfony listeners (e.g. `civi.api.resolve`, `civi.api.prepare`)
+
+See also this [blog post](https://civicrm.org/blog/totten/the-static-is-dead-long-live-the-static) describing the `Civi::` facade in more detail.


### PR DESCRIPTION
Long-term it would be good to add the info contained in the blog post directly into the docs somewhere, but at least in the short term since this is the ONLY mention of Civi::$statics in the dev docs the blog post can at least give more info for now.

@seamuslee001 