### PR TITLE
civilint.md - Split out comments on multiple lines

### DIFF
--- a/docs/tools/civilint.md
+++ b/docs/tools/civilint.md
@@ -5,10 +5,17 @@ Code-style tests ensure a consistent layout across all of the codebase, and they
 Note that civilint may be invoked a few different ways:
 
 ```bash
-civilint # (no arguments) – Check style of any uncommitted changes.
-civilint some/file.php # Check style of a specific file (or list of files).
-git diff --name-only HEAD~1 | civilint - # Check your last commit
-git diff --name-only master | civilint - # Check for changes in your branch (compared to master)
+# (no arguments) – Check style of any uncommitted changes.
+civilint
+
+# Check style of a specific file (or list of files).
+civilint some/file.php
+
+# Check your last commit
+git diff --name-only HEAD~1 | civilint -
+
+# Check for changes in your branch (compared to master)
+git diff --name-only master | civilint -
 ```
 
 See also:


### PR DESCRIPTION
These examples are in a code block  - which prevents wrapping. When reading on the published site, you have to scroll horizontally.

Moving them to separate lines makes them more legible.