### PR TITLE
corrected extension name

### DIFF
--- a/docs/extensions/civix.md
+++ b/docs/extensions/civix.md
@@ -159,8 +159,8 @@ If you want your extension to store data in the database, then you will need to 
 1. Re-install your extension.
 
     ```bash
-    $ cv ext:uninstall org.example.myextension
-    $ cv ext:enable org.example.myextension
+    $ cv ext:uninstall myextension
+    $ cv ext:enable myextension
     ```
     
 Now your entity should be ready to use. Try it out with `cv api MyEntity.create` and `cv api MyEntity.get`. Then [add some tests](#generate-test).


### PR DESCRIPTION
The extension name is just `myextension`, not `com.example.myextension`.

See https://chat.civicrm.org/civicrm/channels/dev-newcomers