### PR TITLE
Fix indentation of code block in hook_civicrm_permission

### DIFF
--- a/docs/hooks/hook_civicrm_permission.md
+++ b/docs/hooks/hook_civicrm_permission.md
@@ -45,7 +45,7 @@ to grant it to users.
             $permissions['delete in Grant Program'] = [
               ts('CiviCRM Grant Program: delete grant program'),                    // if no description, just give an array with the label
             ];
-         ```
+        ```
 ## Returns
 
 -   null


### PR DESCRIPTION
Just a small indentation fix that was breaking the code sample format/highlighting in `hook_civicrm_permission`.