### PR TITLE
Revert "Explain when mailingID and messageTemplateID are passed through"

### DIFF
--- a/docs/hooks/hook_civicrm_alterMailContent.md
+++ b/docs/hooks/hook_civicrm_alterMailContent.md
@@ -15,14 +15,7 @@ tokenizing it.
 
 ## Details
 
-$content - fields include: html, text, subject, groupName, valueName, messageTemplateID, mailingID
-Note that this hook is fired when: 
-
-* creating mailings through the traditional BAO mailer (standard CiviMail)
-* creating mailings through FlexMailer (used by Mosaico)
-* sending emails using message templates, in CRM_Core_BAO_MessageTemplate
-
-In the latter case there is inherently no mailingID, so this will not be supplied. Similarly in the 2 former cases the messageTemplateID is not supplied.
+-   $content - fields include: html, text, subject, groupName, valueName, messageTemplateID
 
 ## Example
 


### PR DESCRIPTION
Reverts civicrm/civicrm-dev-docs#703 - not merge ready - needs core release.