### PR TITLE
dev/core#1615 - Import civicrm-setup docs

### DIFF
--- a/docs/framework/setup/getting-started.md
+++ b/docs/framework/setup/getting-started.md
@@ -1,0 +1,195 @@
+# Getting started
+
+Whether your goal is to improve the `civicrm-setup` library, write a new
+installer, or write a new plugin, it will help to start out by running the
+command-line installer. This can help you understand and experiment with
+the library.
+
+## Get the `civicrm-setup` code
+
+Let's a get a copy of the library.
+
+```
+$ mkdir $HOME/src
+$ git clone https://github.com/civicrm/civicrm-setup $HOME/src/civicrm-setup
+```
+
+Note that this is our developmental copy of the library -- it is not a
+default location that's generally recognized by the software.  However, you
+can set an environment variable to ensure that it's used in subsequent
+commands:
+
+```
+$ export CV_SETUP_PATH=$HOME/src/civicrm-setup 
+```
+
+> __Tip__: If you start a new terminal, you may need to set `CV_SETUP_PATH`
+> again.
+
+## Create a CMS+Civi build
+
+You'll need a copy of WordPress, Drupal, or another Civi-supported CMS. 
+Create this by whatever you means you prefer, e.g.
+
+ * `drush dl ... drush site-install ...`
+ * `wp core download ... wp core install ...`
+ * `civibuild create ...`
+
+The build should include a copy of the CiviCRM source-code in a standard
+location (e.g. `sites/all/modules/civicrm` or `wp-content/plugins/civicrm`).
+If necessary, download the tarball/zipball or clone the git repos.
+
+For the rest of this tutorial, you'll want to be in the root folder of the
+CMS build.
+
+```
+$ cd /path/to/web-root
+```
+
+## Inspect the model
+
+The *model* defines any local installation options.  These values are mostly
+discovered automatically. To inspect them, use the `--debug-model` option, as in:
+
+```
+$ cv core:install --debug-model
+Found code for civicrm-core in /home/myuser/buildkit/build/hydra-wp/wp-content/plugins/civicrm/civicrm
+Found code for civicrm-setup in /home/myuser/src/civicrm-setup
+{
+    "srcPath": "/home/myuser/buildkit/build/hydra-wp/wp-content/plugins/civicrm/civicrm",
+    "setupPath": "/home/myuser/src/civicrm-setup",
+    "settingsPath": "/home/myuser/buildkit/build/hydra-wp/wp-content/uploads/civicrm/civicrm.settings.php",
+    "cms": "WordPress",
+    "cmsBaseUrl": "http://hydra-wp.l",
+    "db": {
+        "server": "127.0.0.1:3307",
+        "username": "hydrawpcms_p7urq",
+        "password": "t0ps3cr3t4r3a1z",
+        "database": "hydrawpcms_p7urq"
+    },
+...
+```
+
+Some options can be customized on the command line . For example, passing `--db=<url>` will change the `db` field:
+
+```
+$ cv core:install --debug-model --db=mysql://otheruser:secret@mysql.example.org/civicrm
+...
+    "db": {
+        "server": "mysql.example.org",
+        "username": "otheruser",
+        "password": "secret",
+        "database": "civicrm"
+    },
+...
+```
+
+To browse a more complete list of options, run `cv core:install --help`.
+
+## Inspect the plugins and events
+
+Most changes are accomplished by adding or patching plugins, and each plugin subscribes to events.
+
+You can inspect the list of plugins and events with the `--debug-event` option. For example:
+
+```
+$ cv core:install --debug-event
+...
+[Event] civi.setup.installFiles
++-------+------------------------------------------------------------------------------------------------------------+
+| Order | Callable                                                                                                   |
++-------+------------------------------------------------------------------------------------------------------------+
+| #1    | closure(/home/myuser/src/civicrm-setup/plugins/common.d/LogEvents.civi-setup.php@30)                       |
+| #2    | closure(/home/myuser/src/civicrm-setup/plugins/installFiles.d/GenerateSiteKey.civi-setup.php@13)           |
+| #3    | closure(/home/myuser/src/civicrm-setup/plugins/installFiles.d/CreateTemplateCompilePath.civi-setup.php@33) |
+| #4    | closure(/home/myuser/src/civicrm-setup/plugins/installFiles.d/InstallSettingsFile.civi-setup.php@43)       |
+| #5    | closure(/home/myuser/src/civicrm-setup/plugins/common.d/LogEvents.civi-setup.php@38)                       |
++-------+------------------------------------------------------------------------------------------------------------+
+...
+```
+
+## Inspect the system requirements
+
+CiviCRM has a number of system requirements that should be met before installation. You can review all of them:
+
+```
+$ cv core:check-req
+Found code for civicrm-core in /home/myuser/buildkit/build/hydra-wp/wp-content/plugins/civicrm/civicrm
+Found code for civicrm-setup in /home/myuser/src/civicrm-setup
++----------+----------+--------------------------------------+-----------------------------------------------------+
+| severity | section  | name                                 | message                                             |
++----------+----------+--------------------------------------+-----------------------------------------------------+
+| info     | database | CiviCRM InnoDB support               | MySQL supports InnoDB                               |
+| info     | database | CiviCRM MySQL AutoIncrementIncrement | MySQL server auto_increment_increment is 1          |
+| info     | database | CiviCRM MySQL Lock Tables            | Can successfully lock and unlock tables             |
+| info     | database | CiviCRM MySQL Temp Tables            | MySQL server supports temporary tables              |
+...
+```
+
+Notice that the `severity` indicates the importance of the message. The severities are:
+
+* `info`: The requirement is met. The message is just informational. Installation may proceed.
+* `warning`: The requirement is partially met. Installation may proceed, but there is some limitation or risk.
+* `error`: The requirement is not met. Installation cannot proceed.
+
+> __Tip__: If you want to focus on warnings and errors, add the `-we` option.
+
+## Run the installer
+
+If all the auto-detection works and all the requirements are met, then installation is straight-forward:
+
+```
+$ cv core:install
+Found code for civicrm-core in /home/myuser/buildkit/build/hydra-wp/wp-content/plugins/civicrm/civicrm
+Found code for civicrm-setup in /home/myuser/src/civicrm-setup
+Creating file /home/myuser/buildkit/build/hydra-wp/wp-content/uploads/civicrm/civicrm.settings.php
+Creating civicrm_* database tables in hydrawpcms_p7urq
+```
+
+However, you could encounter an error.  For example, the model requires a valid `cmsBaseUrl`, but this
+is not auto-detected correctly in Drupal 7. The installer will raise an error because the requirement
+hasn't been met.
+
+```
+$ cv core:install
+Found code for civicrm-core in /home/myuser/buildkit/build/dmaster/sites/all/modules/civicrm
+Found code for civicrm-setup in /home/myuser/src/civicrm-setup
+(cmsBaseUrl) The "cmsBaseUrl" (http://localhost/home/myuser/src/cv/bin/home/myuser/src/cv/bin/) is unavailable or malformed. Consider setting it explicitly.
+                              
+  [Exception]                 
+  Requirements check failed.  
+```
+
+You can resolve this by passing `--cms-base-url`, as in:
+
+```
+$ cv core:install --cms-base-url=http://mysite.localhost
+```
+
+## Run the dev loop
+
+When writing a patch to the installer logic, you may want to alternately
+update the code, re-run the installer, and inspect what happens. This
+can be distilled into a single CLI call, which inclues a few elements:
+
+* Use `cv core:install -f` to force-install. This will remove any old settings-files or database-tables.
+* Use `cv core:install -vvv` to enable very-verbose output. This will log more details about the execution.
+* Use `drush` or `wp-cli` to enable or disable the `civicrm` module.
+
+For example, on WordPress, this single command will uninstall and reinstall:
+
+```
+wp plugin deactivate civicrm ; cv core:install -f -vvv ; wp plugin activate civicrm
+```
+
+Similarly, in Drupal 7:
+
+```
+drush -y dis civicrm ; cv core:install -f -vvv --cms-base-url=http://example.com/ ; drush -y en civicrm
+```
+
+## Test coverage
+
+This library provides little test-coverage on its own.  Instead, the main
+test coverage is provided in the `cv` project (`phpunit4 --group installer`).
+For more details on running that test, consult the documentation in `cv`'s git repo.

--- a/docs/framework/setup/getting-started.md
+++ b/docs/framework/setup/getting-started.md
@@ -1,34 +1,12 @@
 # Getting started
 
-Whether your goal is to improve the `civicrm-setup` library, write a new
+Whether your goal is to improve the `setup` subsystem, write a new
 installer, or write a new plugin, it will help to start out by running the
-command-line installer. This can help you understand and experiment with
-the library.
-
-## Get the `civicrm-setup` code
-
-Let's a get a copy of the library.
-
-```
-$ mkdir $HOME/src
-$ git clone https://github.com/civicrm/civicrm-setup $HOME/src/civicrm-setup
-```
-
-Note that this is our developmental copy of the library -- it is not a
-default location that's generally recognized by the software.  However, you
-can set an environment variable to ensure that it's used in subsequent
-commands:
-
-```
-$ export CV_SETUP_PATH=$HOME/src/civicrm-setup 
-```
-
-> __Tip__: If you start a new terminal, you may need to set `CV_SETUP_PATH`
-> again.
+command-line installer. This can help you inspect and experiment.
 
 ## Create a CMS+Civi build
 
-You'll need a copy of WordPress, Drupal, or another Civi-supported CMS. 
+You'll need a copy of WordPress, Drupal, or another Civi-supported CMS.
 Create this by whatever you means you prefer, e.g.
 
  * `drush dl ... drush site-install ...`
@@ -38,6 +16,13 @@ Create this by whatever you means you prefer, e.g.
 The build should include a copy of the CiviCRM source-code in a standard
 location (e.g. `sites/all/modules/civicrm` or `wp-content/plugins/civicrm`).
 If necessary, download the tarball/zipball or clone the git repos.
+
+!!! tip "Using the uninstaller"
+
+    If you used `civibuild` to create a full site with Civi+CMS, then it does
+    everything needed... and little more. We want a build where the
+    configuration files and database tables don't exist yet.
+    Use `cv core:uninstall` to rollback to this stage.
 
 For the rest of this tutorial, you'll want to be in the root folder of the
 CMS build.
@@ -53,12 +38,12 @@ discovered automatically. To inspect them, use the `--debug-model` option, as in
 
 ```
 $ cv core:install --debug-model
-Found code for civicrm-core in /home/myuser/buildkit/build/hydra-wp/wp-content/plugins/civicrm/civicrm
-Found code for civicrm-setup in /home/myuser/src/civicrm-setup
+Found code for civicrm-core in /var/www/wp-content/plugins/civicrm/civicrm
+Found code for civicrm-setup in /var/www/wp-content/plugins/civicrm/civicrm/setup
 {
-    "srcPath": "/home/myuser/buildkit/build/hydra-wp/wp-content/plugins/civicrm/civicrm",
-    "setupPath": "/home/myuser/src/civicrm-setup",
-    "settingsPath": "/home/myuser/buildkit/build/hydra-wp/wp-content/uploads/civicrm/civicrm.settings.php",
+    "srcPath": "/var/www/wp-content/plugins/civicrm/civicrm",
+    "setupPath": "/var/www/wp-content/plugins/civicrm/civicrm/setup",
+    "settingsPath": "/var/www/wp-content/uploads/civicrm/civicrm.settings.php",
     "cms": "WordPress",
     "cmsBaseUrl": "http://hydra-wp.l",
     "db": {
@@ -86,6 +71,16 @@ $ cv core:install --debug-model --db=mysql://otheruser:secret@mysql.example.org/
 
 To browse a more complete list of options, run `cv core:install --help`.
 
+!!! tip "Improvising with `-m`"
+
+    Several common options, such as `--db`, are documented in the help for `cv core:install`.
+    If you need to update the model with a less visible option, then use `--model` (`-m`)
+    For example, this will load sample data:
+
+    ```
+    $ cv core:install -m loadGenerated=1
+    ```
+
 ## Inspect the plugins and events
 
 Most changes are accomplished by adding or patching plugins, and each plugin subscribes to events.
@@ -96,15 +91,15 @@ You can inspect the list of plugins and events with the `--debug-event` option. 
 $ cv core:install --debug-event
 ...
 [Event] civi.setup.installFiles
-+-------+------------------------------------------------------------------------------------------------------------+
-| Order | Callable                                                                                                   |
-+-------+------------------------------------------------------------------------------------------------------------+
-| #1    | closure(/home/myuser/src/civicrm-setup/plugins/common.d/LogEvents.civi-setup.php@30)                       |
-| #2    | closure(/home/myuser/src/civicrm-setup/plugins/installFiles.d/GenerateSiteKey.civi-setup.php@13)           |
-| #3    | closure(/home/myuser/src/civicrm-setup/plugins/installFiles.d/CreateTemplateCompilePath.civi-setup.php@33) |
-| #4    | closure(/home/myuser/src/civicrm-setup/plugins/installFiles.d/InstallSettingsFile.civi-setup.php@43)       |
-| #5    | closure(/home/myuser/src/civicrm-setup/plugins/common.d/LogEvents.civi-setup.php@38)                       |
-+-------+------------------------------------------------------------------------------------------------------------+
++-------+------------------------------------------------------------------------------------------------+
+| Order | Callable                                                                                       |
++-------+------------------------------------------------------------------------------------------------+
+| #1    | closure(/var/www/.../setup/plugins/common.d/LogEvents.civi-setup.php@30)                       |
+| #2    | closure(/var/www/.../setup/plugins/installFiles.d/GenerateSiteKey.civi-setup.php@13)           |
+| #3    | closure(/var/www/.../setup/plugins/installFiles.d/CreateTemplateCompilePath.civi-setup.php@33) |
+| #4    | closure(/var/www/.../setup/plugins/installFiles.d/InstallSettingsFile.civi-setup.php@43)       |
+| #5    | closure(/var/www/.../setup/plugins/common.d/LogEvents.civi-setup.php@38)                       |
++-------+------------------------------------------------------------------------------------------------+
 ...
 ```
 
@@ -114,8 +109,8 @@ CiviCRM has a number of system requirements that should be met before installati
 
 ```
 $ cv core:check-req
-Found code for civicrm-core in /home/myuser/buildkit/build/hydra-wp/wp-content/plugins/civicrm/civicrm
-Found code for civicrm-setup in /home/myuser/src/civicrm-setup
+Found code for civicrm-core in /var/www/wp-content/plugins/civicrm/civicrm
+Found code for civicrm-setup in /var/www/wp-content/plugins/civicrm/civicrm/setup
 +----------+----------+--------------------------------------+-----------------------------------------------------+
 | severity | section  | name                                 | message                                             |
 +----------+----------+--------------------------------------+-----------------------------------------------------+
@@ -132,7 +127,7 @@ Notice that the `severity` indicates the importance of the message. The severiti
 * `warning`: The requirement is partially met. Installation may proceed, but there is some limitation or risk.
 * `error`: The requirement is not met. Installation cannot proceed.
 
-> __Tip__: If you want to focus on warnings and errors, add the `-we` option.
+> __Tip__: If you want to focus on warnings and errors, use `-we` as in `cv core:check-req -we`
 
 ## Run the installer
 
@@ -140,9 +135,9 @@ If all the auto-detection works and all the requirements are met, then installat
 
 ```
 $ cv core:install
-Found code for civicrm-core in /home/myuser/buildkit/build/hydra-wp/wp-content/plugins/civicrm/civicrm
-Found code for civicrm-setup in /home/myuser/src/civicrm-setup
-Creating file /home/myuser/buildkit/build/hydra-wp/wp-content/uploads/civicrm/civicrm.settings.php
+Found code for civicrm-core in /var/www/wp-content/plugins/civicrm/civicrm
+Found code for civicrm-setup in /var/www/wp-content/plugins/civicrm/civicrm/setup
+Creating file /var/www/wp-content/uploads/civicrm/civicrm.settings.php
 Creating civicrm_* database tables in hydrawpcms_p7urq
 ```
 
@@ -152,12 +147,12 @@ hasn't been met.
 
 ```
 $ cv core:install
-Found code for civicrm-core in /home/myuser/buildkit/build/dmaster/sites/all/modules/civicrm
-Found code for civicrm-setup in /home/myuser/src/civicrm-setup
+Found code for civicrm-core in /var/www/sites/all/modules/civicrm
+Found code for civicrm-setup in /var/www/sites/all/modules/civicrm/setup
 (cmsBaseUrl) The "cmsBaseUrl" (http://localhost/home/myuser/src/cv/bin/home/myuser/src/cv/bin/) is unavailable or malformed. Consider setting it explicitly.
-                              
-  [Exception]                 
-  Requirements check failed.  
+
+  [Exception]
+  Requirements check failed.
 ```
 
 You can resolve this by passing `--cms-base-url`, as in:
@@ -169,12 +164,13 @@ $ cv core:install --cms-base-url=http://mysite.localhost
 ## Run the dev loop
 
 When writing a patch to the installer logic, you may want to alternately
-update the code, re-run the installer, and inspect what happens. This
-can be distilled into a single CLI call, which inclues a few elements:
+update the code, re-run the installer, and inspect what happens. Try to
+distill this into a single CLI call that can be quickly repeated; it
+will likely include:
 
-* Use `cv core:install -f` to force-install. This will remove any old settings-files or database-tables.
-* Use `cv core:install -vvv` to enable very-verbose output. This will log more details about the execution.
-* Use `drush` or `wp-cli` to enable or disable the `civicrm` module.
+* Using `cv core:install -f` to force-install. This will remove any old settings-files or database-tables.
+* Using `cv core:install -vvv` to enable very-verbose output. This will log more details about the execution.
+* Using `drush` or `wp-cli` to enable or disable the `civicrm` module.
 
 For example, on WordPress, this single command will uninstall and reinstall:
 

--- a/docs/framework/setup/getting-started.md
+++ b/docs/framework/setup/getting-started.md
@@ -161,18 +161,18 @@ You can resolve this by passing `--cms-base-url`, as in:
 $ cv core:install --cms-base-url=http://mysite.localhost
 ```
 
-## Run the dev loop
+## Dev loop
 
-When writing a patch to the installer logic, you may want to alternately
-update the code, re-run the installer, and inspect what happens. Try to
-distill this into a single CLI call that can be quickly repeated; it
-will likely include:
+When writing an installer, patch, or plugin using the `setup` subsystem, you may want
+to alternately update the code, re-run the installation, and inspect what happens.
+Try to distill the install/uninstall/reinstall process into a single CLI call that can be quickly repeated.
+It would likely include:
 
 * Using `cv core:install -f` to force-install. This will remove any old settings-files or database-tables.
 * Using `cv core:install -vvv` to enable very-verbose output. This will log more details about the execution.
 * Using `drush` or `wp-cli` to enable or disable the `civicrm` module.
 
-For example, on WordPress, this single command will uninstall and reinstall:
+For example, on WordPress, this command will uninstall and reinstall:
 
 ```
 wp plugin deactivate civicrm ; cv core:install -f -vvv ; wp plugin activate civicrm

--- a/docs/framework/setup/index.md
+++ b/docs/framework/setup/index.md
@@ -1,0 +1,38 @@
+# civicrm-setup
+
+`civicrm-setup` is a library for writing a CiviCRM installer.  It aims to support multiple installers, such as the CLI command `cv`
+(`cv core:install` and `cv core:uninstall`) or per-CMS web-based installers (e.g.  for `civicrm-drupal` or `civicrm-wordpress`).
+
+General design:
+
+* Installers call a high-level API ([Civi\Setup](src/Setup.php)) which supports all major installation tasks/activities -- such as:
+    * Check system requirements (`$setup->checkRequirements()`)
+    * Check installation status (`$setup->checkInstalled()`)
+    * Install data files (`$setup->installFiles()`)
+    * Install database (`$setup->installDatabase()`)
+* A *data-model* ([Civi\Setup\Model](src/Setup/Model.php)) lists all the standard configuration parameters. This data-model is available when executing each task. For example, it includes:
+    * The path to CiviCRM's code (`$model->srcPath`)
+    * The system language (`$model->lang`)
+    * The DB credentials (`$model->db`)
+* Each major task corresponds to an [*event*](https://github.com/civicrm/civicrm-setup/tree/master/src/Setup/Event) -- such as:
+    * `civi.setup.checkRequirements`
+    * `civi.setup.checkInstalled`
+    * `civi.setup.installFiles`
+    * `civi.setup.installDatabase`
+* *Plugins* (`plugins/*/*.civi-setup.php`) work with the model and the events. For example:
+    * The plugin `init/WordPress.civi-setup.php` runs during initialization (`civi.setup.init`). It reads the WordPress config (e.g.`get_locale()` and `DB_HOST`) then updates the model (`$model->lang` and `$model->db`).
+    * The plugin `installDatabase/SetLanguage.civi-setup.php` runs when installing the database (`civi.setup.installDatabase`). It reads the `$model->lang` and updates various Civi settings.
+
+Key features:
+
+* The library can be used by other projects -- such as `cv`, `civicrm-drupal`, `civicrm-wordpress` -- to provide an installation process.
+* It is a *leap*. It can coexist with the old installer, and it lives in a separate project/repo which can be deployed optionally.
+    * _Example_: The `civicrm-wordpress` integration is phasing-in support for the new installer. By default, it uses the old installer. If you create a file `civicrm/.use-civicrm-setup`, then it will use the new installer.
+* It has minimal external dependencies. (The codebase for CiviCRM and its dependencies must be available -- but nothing else is needed.)
+
+## Documentation
+
+* [Getting started](docs/getting-started.md)
+* [Writing an installer](docs/new-installer.md)
+* [Writing a plugin](docs/new-plugin.md)
+* [Managing plugins](docs/plugins.md)

--- a/docs/framework/setup/index.md
+++ b/docs/framework/setup/index.md
@@ -32,7 +32,7 @@ Key features:
 
 ## Documentation
 
-* [Getting started](docs/getting-started.md)
-* [Writing an installer](docs/new-installer.md)
-* [Writing a plugin](docs/new-plugin.md)
-* [Managing plugins](docs/plugins.md)
+* [Getting started](getting-started.md)
+* [Writing an installer](new-installer.md)
+* [Writing a plugin](new-plugin.md)
+* [Managing plugins](plugins.md)

--- a/docs/framework/setup/index.md
+++ b/docs/framework/setup/index.md
@@ -29,10 +29,3 @@ Key features:
 * It is a *leap*. It can coexist with the old installer, and it lives in a separate project/repo which can be deployed optionally.
     * _Example_: The `civicrm-wordpress` integration is phasing-in support for the new installer. By default, it uses the old installer. If you create a file `civicrm/.use-civicrm-setup`, then it will use the new installer.
 * It has minimal external dependencies. (The codebase for CiviCRM and its dependencies must be available -- but nothing else is needed.)
-
-## Documentation
-
-* [Getting started](getting-started.md)
-* [Writing an installer](new-installer.md)
-* [Writing a plugin](new-plugin.md)
-* [Managing plugins](plugins.md)

--- a/docs/framework/setup/index.md
+++ b/docs/framework/setup/index.md
@@ -1,7 +1,18 @@
-# civicrm-setup
+!!! note "Status of `install` and `setup` subsystems"
 
-`civicrm-setup` is a library for writing a CiviCRM installer.  It aims to support multiple installers, such as the CLI command `cv`
-(`cv core:install` and `cv core:uninstall`) or per-CMS web-based installers (e.g.  for `civicrm-drupal` or `civicrm-wordpress`).
+    The CiviCRM `setup` subsystem is a refactored/rewritten version of the older `install` subsystem.
+    There is a Gitlab issue for [tracking the migration from `install` to `setup`](https://lab.civicrm.org/dev/core/issues/1615).
+
+The CiviCRM `setup` subsystem facilitates installation and configuration.  It aims to support multiple installers, such
+as a generic CLI (`cv core:install` and `cv core:uninstall`), a generic web-based installer, and specialized/scripted installers
+for different environments and use-cases.
+
+Key features:
+
+* The subsystem can be used by other projects -- such as `cv`, `civicrm-drupal`, `civicrm-wordpress` -- to provide an installation process.
+* It is a *leap*. It can coexist with the old installer.
+    * _Example_: The `civicrm-wordpress` integration is phasing-in support for the new installer. By default, it uses the old installer. If you create a file `civicrm/.use-civicrm-setup`, then it will use the new installer.
+* It has minimal external dependencies. (The codebase for CiviCRM and its dependencies must be available -- but nothing else is needed.)
 
 General design:
 
@@ -10,11 +21,11 @@ General design:
     * Check installation status (`$setup->checkInstalled()`)
     * Install data files (`$setup->installFiles()`)
     * Install database (`$setup->installDatabase()`)
-* A *data-model* ([Civi\Setup\Model](src/Setup/Model.php)) lists all the standard configuration parameters. This data-model is available when executing each task. For example, it includes:
+* A *data-model* ([Civi\Setup\Model](https://github.com/civicrm/civicrm-core/tree/master/setup/src/Setup/Model.php)) lists all the standard configuration parameters. This data-model is available when executing each task. For example, it includes:
     * The path to CiviCRM's code (`$model->srcPath`)
     * The system language (`$model->lang`)
     * The DB credentials (`$model->db`)
-* Each major task corresponds to an [*event*](https://github.com/civicrm/civicrm-setup/tree/master/src/Setup/Event) -- such as:
+* Each major task corresponds to an [*event*](https://github.com/civicrm/civicrm-core/tree/master/setup/src/Setup/Event) -- such as:
     * `civi.setup.checkRequirements`
     * `civi.setup.checkInstalled`
     * `civi.setup.installFiles`
@@ -23,9 +34,3 @@ General design:
     * The plugin `init/WordPress.civi-setup.php` runs during initialization (`civi.setup.init`). It reads the WordPress config (e.g.`get_locale()` and `DB_HOST`) then updates the model (`$model->lang` and `$model->db`).
     * The plugin `installDatabase/SetLanguage.civi-setup.php` runs when installing the database (`civi.setup.installDatabase`). It reads the `$model->lang` and updates various Civi settings.
 
-Key features:
-
-* The library can be used by other projects -- such as `cv`, `civicrm-drupal`, `civicrm-wordpress` -- to provide an installation process.
-* It is a *leap*. It can coexist with the old installer, and it lives in a separate project/repo which can be deployed optionally.
-    * _Example_: The `civicrm-wordpress` integration is phasing-in support for the new installer. By default, it uses the old installer. If you create a file `civicrm/.use-civicrm-setup`, then it will use the new installer.
-* It has minimal external dependencies. (The codebase for CiviCRM and its dependencies must be available -- but nothing else is needed.)

--- a/docs/framework/setup/new-installer.md
+++ b/docs/framework/setup/new-installer.md
@@ -1,0 +1,97 @@
+# Writing an installer
+
+For a CMS integration (e.g. `civicrm-drupal` or `civicrm-wordpress`) which aims to incorporate an installer, you'll
+first need to initialize the runtime and get a reference to the `$setup` object. The general steps are:
+
+* Bootstrap the CMS/host environment.
+    * __Tip__: You may not need to do anything here -- this is often implicitly handled by the host environment.
+    * __Tip__: Initializing this first ensures that we can *automatically discover* information about the host environment.
+* (Optional) Check for `civicrm/.use-civicrm-setup`
+    * If you're incrementally replacing the old installer with the new installer, you can check for a signal that allows the system-builder to toggle between the old/new installers. Specifically, in the `civicrm-core` folder, look for a file named `.use-civicrm-setup`.
+    * If you're writing an installer for a new build/channel, then you probably don't need to worry about this.
+* Load the class-loader.
+    * __Ex__: If you use `civicrm` as a distinct sub-project (with its own `vendor` and autoloader), then you may need to load `CRM/Core/ClassLoader.php` and call `register()`.
+    * __Ex__: If you use `composer` to manage the full site-build (with CMS+Civi+dependencies), then you may not need to take any steps.
+* Initialize the `\Civi\Setup` subsystem.
+    * Call `\Civi\Setup::init($modelValues = array(), $pluginCallback = NULL)`.
+    * The `$modelValues` provides an opportunity to seed the configuration options, such as DB credentials and file-paths. See the fields defined for the [Model](src/Setup/Model.php).
+    * The `$pluginCallback` (`function(array $files) => array $files`) provides an opportunity to add/remove/override plugin files.
+    * __Tip__: During initialization, some values may be autodetected. After initialization, you can inspect or revise these with `Civi\Setup::instance()->getModel()`.
+* Get a reference to the `$setup` API.
+    * Call `$setup = Civi\Setup::instance()`.
+
+For example:
+
+```php
+<?php
+$civicrmCore = '/path/to/civicrm';
+if (file_exists($civicrmCore . DIRECTORY_SEPARATOR . '.use-civicrm-setup')) {
+  require_once implode(DIRECTORY_SEPARATOR, [$civicrmCore, 'CRM', 'Core', 'ClassLoader.php']);
+  CRM_Core_ClassLoader::singleton()->register();
+  \Civi\Setup::assertProtocolCompatibility(1.0);
+  \Civi\Setup::init([
+    'cms' => 'WordPress',
+    'srcPath' => $civicrmCore,
+  ]);
+  $setup = Civi\Setup::instance();
+}
+```
+
+Once you have a copy of the `$setup` API, there are a few ways to work with it. For example, you might load
+the pre-built installation form:
+
+```php
+<?php
+// Create and execute the default setup controller.
+$ctrl = \Civi\Setup::instance()->createController()->getCtrl();
+$ctrl->setUrls(array(
+  'ctrl' => 'url://for/the/install/controller',
+  'res' => 'url://for/civicrm-setup/res',
+  'jquery.js' => 'url://for/jquery.js',
+  'font-awesome.css' ='url://for/font-awesome.css',
+));
+\Civi\Setup\BasicRunner::run($ctrl);
+```
+
+The `BasicRunner::run()` function uses PHP's standard, global I/O (e.g. 
+`$_POST` for input; `header()` for headers; `echo` for output). 
+However, some frameworks have their own I/O conventions.  You can get more
+direct control of I/O by calling the controller directly, e.g.:
+
+```php
+<?php
+list ($httpHeaders, $htmlBody) = $ctrl->run($_SERVER['REQUEST_METHOD'], $_POST);
+```
+
+Alternatively, you might build a custom UI or an automated installer. `$setup` provides a number of functions:
+
+* `$setup->getModel()`: Get a copy of the `Model`. You may want to tweak the model's data before performing installation.
+* `$setup->checkAuthorized()`: Determine if the current user is authorized to perform an installation.
+* `$setup->checkInstalled()`: Determine if CiviCRM is already installed.
+* `$setup->checkRequirements()`: Determine if the local system meets the installation requirements.
+* `$setup->installFiles()`: Create data files, such as `civicrm.settings.php` and `templates_c`.
+* `$setup->installDatabase()`: Create database schema (tables, views, etc). Perform first bootstrap and configure the system.
+* `$setup->uninstallDatabase()`: Purge database schema (tables, views, etc).
+* `$setup->uninstallFiles()`: Purge data files, such as `civicrm.settings.php`.
+
+The typical install algorithm would be:
+
+```php
+if (!$setup->checkAuthorized()->isAuthorized()) {
+  exit("Sorry, you are not authorized to perform installation.");
+}
+
+$reqs = $setup->checkRequirements();
+if ($reqs->getErrors()) {
+  print_r($reqs->getErrors());
+  exit("Cannot install. Please address the system requirements." );
+}
+
+$installed = $setup->checkInstalled();
+if ($installed->isSettingInstalled() || $installed->isDatabaseInstalled()) {
+  exit("Cannot install. CiviCRM has already been installed.");
+}
+
+$setup->installFiles();
+$setup->installDatabase();
+```

--- a/docs/framework/setup/new-installer.md
+++ b/docs/framework/setup/new-installer.md
@@ -1,6 +1,6 @@
 # Writing an installer
 
-# Bootstrap
+## Bootstrap
 
 For a CMS integration (e.g. `civicrm-drupal` or `civicrm-wordpress`) which aims to incorporate an installer, you'll
 first need to initialize the runtime and get a reference to the `$setup` object. The general steps are:

--- a/docs/framework/setup/new-installer.md
+++ b/docs/framework/setup/new-installer.md
@@ -1,23 +1,24 @@
 # Writing an installer
 
+# Bootstrap
+
 For a CMS integration (e.g. `civicrm-drupal` or `civicrm-wordpress`) which aims to incorporate an installer, you'll
 first need to initialize the runtime and get a reference to the `$setup` object. The general steps are:
 
-* Bootstrap the CMS/host environment.
-    * __Tip__: You may not need to do anything here -- this is often implicitly handled by the host environment.
+1. Bootstrap the CMS/host environment.
+    * __Tip__: You may not need to do anything -- this is often implicitly handled by the host environment.
     * __Tip__: Initializing this first ensures that we can *automatically discover* information about the host environment.
-* Load the class-loader.
+2. Load the Civi class-loader(s).
     * __Ex__: If you use `civicrm` as a distinct sub-project (with its own `vendor` and autoloader), then you may need to load `CRM/Core/ClassLoader.php` and call `register()`.
     * __Ex__: If you use `composer` to manage the full site-build (with CMS+Civi+dependencies), then you may not need to take any steps.
-* Initialize the `\Civi\Setup` subsystem.
-    * Call `\Civi\Setup::init($modelValues = array(), $pluginCallback = NULL)`.
-    * The `$modelValues` provides an opportunity to seed the configuration options. This is usually just the `cms` and `srcPath`.
-      Additionally values will be autodetected via plugin.
-    * The `$pluginCallback` (`function(array $files) => array $files`) provides an opportunity to add/remove/override plugin files.
-    * __Tip__: During initialization, some values may be autodetected. After initialization, you can inspect or revise these with `Civi\Setup::instance()->getModel()`.
-* Get a reference to the `$setup` API.
+3. Initialize the `\Civi\Setup` subsystem.
+    * Call `\Civi\Setup::init($modelValues = [], $pluginCallback = NULL)`.
+    * The `$modelValues` provide an opportunity to seed the configuration. This is usually just the `cms` and `srcPath`.
+    * During initialization, additional `$modelValues` will be autodetected. After initialization, you can inspect or override these with `\Civi\Setup::instance()->getModel()`.
+    * The `$pluginCallback` provides an opportunity to [add/remove/override plugins](/framework/setup/plugins.md).
+4. Get a reference to the `$setup` API.
     * Call `$setup = Civi\Setup::instance()`.
-* (Optional) Customize the model
+5. (Optional) Customize the model
     * __Ex__: During initialization, the auto-detection may use the CMS DB credentials for the Civi DB. If you'd prefer to use different credentials, then update `$setup->getModel()->db`.
     * __Tip__: For details, see the documentation in [Civi\Setup\Model](https://github.com/civicrm/civicrm-core/tree/master/setup/src/Setup/Model.php).
 
@@ -37,41 +38,54 @@ $setup = Civi\Setup::instance();
 ```
 
 Once you have a copy of the `$setup` API, there are a few ways to work with it. For example, you might load
-the pre-built installation form:
+the pre-built web-based installer or perform a headless install.
+
+## Web Installer API
+
+The web installer provides a small, HTML-based GUI for performing Civi installation. It can be
+embedded in other HTML GUIs. Instantiate and execute the controller:
 
 ```php
 <?php
-// Create and execute the default setup controller.
-$ctrl = \Civi\Setup::instance()->createController()->getCtrl();
-$ctrl->setUrls(array(
-  'ctrl' => 'url://for/the/install/controller',
-  'res' => 'url://for/civicrm-setup/res',
-  'jquery.js' => 'url://for/jquery.js',
-  'font-awesome.css' ='url://for/font-awesome.css',
-));
-\Civi\Setup\BasicRunner::run($ctrl);
+function myframework_page_ctrl() {
+  // Create and execute the default setup controller.
+  $ctrl = \Civi\Setup::instance()->createController()->getCtrl();
+  $ctrl->setUrls(array(
+    'ctrl' => 'url://for/the/install/controller',
+    'res' => 'url://for/civicrm/setup/res',
+    'jquery.js' => 'url://for/jquery.js',
+    'font-awesome.css' ='url://for/font-awesome.css',
+  ));
+  \Civi\Setup\BasicRunner::run($ctrl);
+}
 ```
 
-The `BasicRunner::run()` function uses PHP's standard, global I/O (e.g. 
-`$_POST` for input; `header()` for headers; `echo` for output). 
-However, some frameworks have their own I/O conventions.  You can get more
-direct control of I/O by calling the controller directly, e.g.:
+The `BasicRunner::run()` executes the controller.  It uses PHP's standard, global I/O (e.g.  `$_POST` for input;
+`header()` for headers; `echo` for output).
+
+Some frameworks have their own I/O conventions which don't use PHP's globals.  You can integrate with these frameworks
+by omitting the `BasicRunner`; instead, call the controller:
 
 ```php
 <?php
 list ($httpHeaders, $htmlBody) = $ctrl->run($_SERVER['REQUEST_METHOD'], $_POST);
 ```
 
-Alternatively, you might build a custom UI or an automated installer. `$setup` provides a number of functions:
+Observe that the `run()` function needs some HTTP inputs (i.e.  the HTTP method plus any available post data) and
+returns HTTP outputs (i.e.  headers and the HTML body). You will need to determine equivalents in your framework.
 
-* `$setup->getModel()`: Get a copy of the `Model`. You may want to tweak the model's data before performing installation.
-* `$setup->checkAuthorized()`: Determine if the current user is authorized to perform an installation.
-* `$setup->checkInstalled()`: Determine if CiviCRM is already installed.
-* `$setup->checkRequirements()`: Determine if the local system meets the installation requirements.
-* `$setup->installFiles()`: Create data files, such as `civicrm.settings.php` and `templates_c`.
-* `$setup->installDatabase()`: Create database schema (tables, views, etc). Perform first bootstrap and configure the system.
-* `$setup->uninstallDatabase()`: Purge database schema (tables, views, etc).
-* `$setup->uninstallFiles()`: Purge data files, such as `civicrm.settings.php`.
+## General Installer API
+
+Alternatively, you might build a custom UI or an automated installer. `$setup` provides a number of functions for this purpose:
+
+* `getModel()`: Get a copy of the `Model`. You may want to tweak the model's data before performing installation.
+* `checkAuthorized()`: Determine if the current user is authorized to perform an installation.
+* `checkInstalled()`: Determine if CiviCRM is already installed.
+* `checkRequirements()`: Determine if the local system meets the installation requirements.
+* `installFiles()`: Create data files, such as `civicrm.settings.php` and `templates_c`.
+* `installDatabase()`: Create database schema (tables, views, etc). Perform first bootstrap and configure the system.
+* `uninstallDatabase()`: Purge database schema (tables, views, etc).
+* `uninstallFiles()`: Purge data files, such as `civicrm.settings.php`.
 
 The typical install algorithm would be:
 

--- a/docs/framework/setup/new-installer.md
+++ b/docs/framework/setup/new-installer.md
@@ -6,35 +6,34 @@ first need to initialize the runtime and get a reference to the `$setup` object.
 * Bootstrap the CMS/host environment.
     * __Tip__: You may not need to do anything here -- this is often implicitly handled by the host environment.
     * __Tip__: Initializing this first ensures that we can *automatically discover* information about the host environment.
-* (Optional) Check for `civicrm/.use-civicrm-setup`
-    * If you're incrementally replacing the old installer with the new installer, you can check for a signal that allows the system-builder to toggle between the old/new installers. Specifically, in the `civicrm-core` folder, look for a file named `.use-civicrm-setup`.
-    * If you're writing an installer for a new build/channel, then you probably don't need to worry about this.
 * Load the class-loader.
     * __Ex__: If you use `civicrm` as a distinct sub-project (with its own `vendor` and autoloader), then you may need to load `CRM/Core/ClassLoader.php` and call `register()`.
     * __Ex__: If you use `composer` to manage the full site-build (with CMS+Civi+dependencies), then you may not need to take any steps.
 * Initialize the `\Civi\Setup` subsystem.
     * Call `\Civi\Setup::init($modelValues = array(), $pluginCallback = NULL)`.
-    * The `$modelValues` provides an opportunity to seed the configuration options, such as DB credentials and file-paths. See the fields defined for the [Model](src/Setup/Model.php).
+    * The `$modelValues` provides an opportunity to seed the configuration options. This is usually just the `cms` and `srcPath`.
+      Additionally values will be autodetected via plugin.
     * The `$pluginCallback` (`function(array $files) => array $files`) provides an opportunity to add/remove/override plugin files.
     * __Tip__: During initialization, some values may be autodetected. After initialization, you can inspect or revise these with `Civi\Setup::instance()->getModel()`.
 * Get a reference to the `$setup` API.
     * Call `$setup = Civi\Setup::instance()`.
+* (Optional) Customize the model
+    * __Ex__: During initialization, the auto-detection may use the CMS DB credentials for the Civi DB. If you'd prefer to use different credentials, then update `$setup->getModel()->db`.
+    * __Tip__: For details, see the documentation in [Civi\Setup\Model](https://github.com/civicrm/civicrm-core/tree/master/setup/src/Setup/Model.php).
 
 For example:
 
 ```php
 <?php
 $civicrmCore = '/path/to/civicrm';
-if (file_exists($civicrmCore . DIRECTORY_SEPARATOR . '.use-civicrm-setup')) {
-  require_once implode(DIRECTORY_SEPARATOR, [$civicrmCore, 'CRM', 'Core', 'ClassLoader.php']);
-  CRM_Core_ClassLoader::singleton()->register();
-  \Civi\Setup::assertProtocolCompatibility(1.0);
-  \Civi\Setup::init([
-    'cms' => 'WordPress',
-    'srcPath' => $civicrmCore,
-  ]);
-  $setup = Civi\Setup::instance();
-}
+require_once implode(DIRECTORY_SEPARATOR, [$civicrmCore, 'CRM', 'Core', 'ClassLoader.php']);
+CRM_Core_ClassLoader::singleton()->register();
+\Civi\Setup::assertProtocolCompatibility(1.0);
+\Civi\Setup::init([
+  'cms' => 'WordPress',
+  'srcPath' => $civicrmCore,
+]);
+$setup = Civi\Setup::instance();
 ```
 
 Once you have a copy of the `$setup` API, there are a few ways to work with it. For example, you might load

--- a/docs/framework/setup/new-plugin.md
+++ b/docs/framework/setup/new-plugin.md
@@ -1,0 +1,81 @@
+# Writing a plugin
+
+A plugin is a PHP file with these characteristics:
+
+* The file's name ends in `*.civi-setup.php`. (Plugins in `civicrm-setup/plugins/*.civi-setup.php` are autodetected.)
+* The file has a guard at the top (`defined('CIVI_SETUP')`). If this constant is missing, then bail out. In case the file becomes accessible on the web, this prevents direct execution.
+* The file's logic locates the event-dispatcher and registers listeners, e.g. `\Civi\Setup::disptacher()->addListener($eventName, $callback)`.
+
+For example, here is a basic plugin that logs a message during database installation:
+
+```php
+<?php
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.installDatabase', function (\Civi\Setup\Event\InstallDatabaseEvent $event) {
+    \Civi\Setup::log()->info("I like to run the plugin during installation.");
+  });
+```
+
+Observe that the primary way for a plugin to interact with the system is to register for events (using Symfony's
+`EventDispatcher`). Most methods in the `Civi\Setup` API have a corresponding event name and event class:
+
+* `\Civi\Setup::init()` => `civi.setup.init` => `Civi\Setup\Event\InitEvent`
+* `\Civi\Setup::checkAuthorized()` => `civi.setup.checkAuthorized` => `Civi\Setup\Event\CheckAuthorizedEvent`
+* `\Civi\Setup::checkInstalled()` => `civi.setup.checkInstalled` => `Civi\Setup\Event\CheckInstalledEvent`
+* `\Civi\Setup::checkRequirements()` => `civi.setup.checkRequirements` => `Civi\Setup\Event\CheckRequirementsEvent`
+* `\Civi\Setup::installFiles()` => `civi.setup.installFiles` => `Civi\Setup\Event\InstallFilesEvent`
+* `\Civi\Setup::installDatabase()` => `civi.setup.installDatabase` => `Civi\Setup\Event\InstallDatabaseEvent`
+* `\Civi\Setup::uninstallFiles()` => `civi.setup.uninstallFiles` => `Civi\Setup\Event\UninstallFilesEvent`
+* `\Civi\Setup::uninstallDatabase()` => `civi.setup.uninstallDatabase` => `Civi\Setup\Event\UninstallDatabaseEvent`
+
+For events related to the built-in web UI, the names are slightly different:
+
+* `\Civi\Setup::createController()` => `civi.setupui.construct` => `Civi\Setup\UI\Event\UIConstructEvent`
+* `\Civi\Setup\UI\SetupController::run()` => `civi.setupui.run` => `Civi\Setup\UI\Event\UIRunEvent`
+* `\Civi\Setup\UI\SetupController::boot()` => `civi.setupui.boot` => `Civi\Setup\UI\Event\UIBootEvent`
+
+All events provide access to the setup data-model.
+
+> __Ex__: To get the path to the `civicrm.settings.php` file, read `$event->getModel()->settingsPath`.
+
+Some events provide additional methods for relaying additional information. For example:
+
+* For `civi.setup.checkRequirements`, use `$event->addError(...)` to record an error that prevents installation.  Similarly, use
+  `addWarning(...)` and `addInfo(...)` to report less critical issues.
+* For `civi.setup.checkAuthorized`, use `$event->setAuthorized(bool $authorized)` to indicate whether authorization is permitted,
+  and use `$event->isAuthorized()` to see if authorization has been permitted.
+* For `civi.setupui.run`, the list of HTTP inputs is available as `$event->getFields()`.
+
+## What's in a file name?
+
+The `plugins/` folder is *loosely* organized based on how the plugin fits into
+the system.  Let's take a few example files (at time of writing):
+
+```
+plugins/checkRequirements/CheckBaseUrl.civi-setup.php
+plugins/checkRequirements/CheckDbWellFormed.civi-setup.php
+plugins/common/LogEvents.civi-setup.php
+plugins/installDatabase/InstallExtensions.civi-setup.php
+plugins/installDatabase/InstallSchema.civi-setup.php
+plugins/installDatabase/InstallSettings.civi-setup.php
+```
+
+Notice a pattern?
+
+* The files under `plugins/checkRequirements` are all plugins which listen to the `civi.setup.checkRequirements` event.
+* The files under `plugins/installDatabase` are all plugins which listen to the `civi.setup.installDatabase` event.
+
+Most plugins only handle one event, so it's a convenient way to organize them.  However, this is just a
+*convention*.  It's entirely legitimate for a plugin to listen to multiple events. For example:
+
+* `common/LogEvents.civi-setup.php` listens to many events.
+* `blocks/*` define visible blocks for the built-in web UI. Many of these listen to 2-3 events.
+
+Tips:
+
+* If you write a new plugin, should it handle one event or multiple? Do whatever is best (on the whole) for improving the concept/coupling/cohesion. This *usually* means writing a small/narrow plugin, but it doesn't necessarily.
+* Browsing the folders provides a high-level skim. Try to respect this in framing new plugins, but don't assume that it's perfect. For detailed inspection or debugging, use `cv core:install --debug-event`.

--- a/docs/framework/setup/plugins.md
+++ b/docs/framework/setup/plugins.md
@@ -1,0 +1,27 @@
+# Managing plugins
+
+Plugins in `civicrm-setup/plugins/*/*.civi-setup.php` are automatically
+detected and loaded.  The simplest way to manage plugins is adding and
+removing files from this folder.
+
+However, you may find it useful to manage plugins programmatically.  For
+example, the `civicrm-drupal` integration or the `civicrm-wordpress`
+integration might refine the installation process by:
+
+* Adding a new plugin
+* Removing a default plugin
+
+To programmatically manage plugins, take note of the
+`\Civi\Setup::init(...)` function.  It accepts an argument,
+`$pluginCallback`, which can edit the plugin list. For example:
+
+```php
+<?php
+function myPluginCallback($files) {
+  $files['ExtraWordPressInstallPlugin'] = '/path/to/ExtraWordPressInstallPlugin.php';
+  ksort($files);
+  return $files;
+}
+
+\Civi\Setup::init(..., 'myPluginCallback');
+```

--- a/docs/framework/setup/plugins.md
+++ b/docs/framework/setup/plugins.md
@@ -1,6 +1,4 @@
-# Managing plugins
-
-Plugins in `civicrm-setup/plugins/*/*.civi-setup.php` are automatically
+Plugins in `civicrm/setup/plugins/*/*.civi-setup.php` are automatically
 detected and loaded.  The simplest way to manage plugins is adding and
 removing files from this folder.
 
@@ -13,12 +11,14 @@ integration might refine the installation process by:
 
 To programmatically manage plugins, take note of the
 `\Civi\Setup::init(...)` function.  It accepts an argument,
-`$pluginCallback`, which can edit the plugin list. For example:
+`$pluginCallback`, which can edit the plugin list.
+
+For example, this would add a custom plugin named `ExtraJoompralInstallPlugin`:
 
 ```php
 <?php
 function myPluginCallback($files) {
-  $files['ExtraWordPressInstallPlugin'] = '/path/to/ExtraWordPressInstallPlugin.php';
+  $files['ExtraJoompralInstallPlugin'] = '/path/to/ExtraJoompralInstallPlugin.php';
   ksort($files);
   return $files;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -263,6 +263,12 @@ pages:
   - Routing: framework/routing.md
   - Resources Reference: framework/resources.md
   - Setting Reference: framework/setting.md
+  - Setup Reference:
+    - Overview: framework/setup/index.md
+    - Getting Started: framework/setup/getting-started.md
+    - New Installer: framework/setup/new-installer.md
+    - New Plugin: framework/setup/new-plugin.md
+    - Manage Plugins: framework/setup/plugins.md
   - Template Reference:
     - Templates: framework/templates/index.md
     - Customizing Templates: framework/templates/customizing.md


### PR DESCRIPTION
Per [dev/core#1615](https://lab.civicrm.org/dev/core/issues/1615), the `civicrm-setup.git` should get assimilated. The code has been [merged](https://github.com/civicrm/civicrm-core/pull/16618) into `civicrm-core.git`, so the docs should go to `civicrm-dev-docs.git`.

~~This PR is currently WIP - some of the content should be rephrased/reconsidered for the new position.~~