### PR TITLE
Consolidate buildkit requirements (basics/requirements.md, tools/buildkit.md)

### DIFF
--- a/docs/basics/requirements.md
+++ b/docs/basics/requirements.md
@@ -17,9 +17,9 @@ There are many ways to install MySQL, PHP, and other dependencies -- for example
 
 Civi development should work with most packages -- with a priviso: ***the command-line must support standard command names*** (eg `git`, `php`, `node`, `mysql`, `mysqldump`, etc).
 
-Some environments (e.g. most Linux distributions) are configured properly out-of-the-box.
+Some environments (e.g. most Linux distributions) are configured properly out-of-the-box. Other environments (e.g. MAMP and XAMPP) may require configuring the `PATH`.
 
-Other environments (e.g. MAMP and XAMPP) may require configuring the `PATH`. (See, e.g., [Setup Command-Line PHP](/standards/php.md).)
+<!-- FIXME: There should be a link about diagnosing/fixing paths for third-party binaries. TLDR: `find / -name php -executable` and then update `PATH` via bashrc/bash_profile/whatever -->
 
 ## Buildkit
 

--- a/docs/basics/requirements.md
+++ b/docs/basics/requirements.md
@@ -2,23 +2,24 @@
 
 ## Languages and Services
 
--   Unix-like environment (Linux, OS X, or a virtual machine)
--   [PHP v7.0+](http://php.net/)
--   [MySQL v5.7.5+](http://mysql.com/) or [MariaDB 10.0.2+](https://mariadb.org/)
--   [NodeJS](https://nodejs.org/)
--   [Git](https://git-scm.com/)
--   Recommended: Apache HTTPD v2.2+
--   Recommended: Ruby/Rake
+* Required
+    - Unix-like environment (Linux, OS X, or a virtual machine)
+    - [PHP v7.0+](http://php.net/) including the following extensions: `bcmath curl gd gettext imap intl imagick json mbstring openssl pdo_mysql phar posix soap zip`
+    - [MySQL v5.7.5+](http://mysql.com/) or [MariaDB 10.0.2+](https://mariadb.org/), including both client and server
+    - [NodeJS v8+](https://nodejs.org/)
+    - [Git](https://git-scm.com/)
+* Recommended (for `civibuild` / `amp`):
+    - Apache HTTPD v2.2 or v2.4 including the `mod_rewrite` module and, on SUSE, possibly `mod_access_compat` (This list may not be exhaustive.)
 
 ## Command Line
 
 There are many ways to install MySQL, PHP, and other dependencies -- for example, `apt-get` and `yum` can download packages automatically; `php.net` and `mysql.com` provide standalone installers; and MAMP/XAMPP provide bundled installers.
 
-Civi development should work with most packages -- but there's one proviso: ***the command-line must support standard commands***  (`php`, `mysql`, `node`, `git`, `bash`, etc).
+Civi development should work with most packages -- with a priviso: ***the command-line must support standard command names*** (eg `git`, `php`, `node`, `mysql`, `mysqldump`, etc).
 
-Some packages are configured properly out-of-the-box. (Linux distributions do a pretty good job of this.) Other packages require extra configuration steps.
+Some environments (e.g. most Linux distributions) are configured properly out-of-the-box.
 
-In subsequent steps, the download script will attempt to identify misconfigurations and display an appropriate message.
+Other environments (e.g. MAMP and XAMPP) may require configuring the `PATH`. (See, e.g., [Setup Command-Line PHP](/standards/php.md).)
 
 ## Buildkit
 

--- a/docs/tools/buildkit.md
+++ b/docs/tools/buildkit.md
@@ -75,22 +75,9 @@ More information is in the Readme: https://github.com/michaelmcandrew/civicrm-bu
 
 ### Generic {:#other-platforms}
 
-You may install buildkit in other environments. The main pre-requisites are:
+You may download buildkit in an existing Unix-style environment if it meets the [system requirements](/basics/requirements.md).
 
-* Linux or OS X
-* Git
-* PHP 5.6+ (7.2+ recommended), including the following extensions: `bcmath curl gd gettext imap intl imagick json mbstring openssl pdo_mysql phar posix soap zip`
-* NodeJS 8+
-* NPM
-
-[amp](https://github.com/totten/amp) and [civibuild](/tools/civibuild.md) also require:
-
-* Apache 2.2 or 2.4, including the `mod_rewrite` module and, on SUSE, possibly `mod_access_compat` (This list may not be exhaustive.)
-* MySQL 5.5+ (5.7+ recommended), including both client and server
-
-All pre-requisites must support command-line access using the standard command names (`git`, `php`, `node`, `mysql`, `mysqldump`, etc). In some environments, you may need to enable these commands by configuring `PATH` -- this is especially true for MAMP, XAMPP, and other downloaded packages. (See, e.g., [Setup Command-Line PHP](/standards/php.md).)
-
-Once the pre-requisites are met, download buildkit to `~/buildkit`:
+Simply clone the `civicrm-buildkit.git` repo and run `civi-download-tools`, as in:
 
 ```bash
 $ git clone https://github.com/civicrm/civicrm-buildkit.git ~/buildkit
@@ -98,6 +85,17 @@ $ cd ~/buildkit
 $ ./bin/civi-download-tools
 ```
 
+In the above example, all tools are downloaded under `~/buildkit`.
+
+!!! tip "Evaluating system requirements"
+
+    When using the generic steps, a primary consideration will be meeting the [system requirements](/basics/requirements.md).
+    It is common for personal/bespoke environments to have a couple of issues meeting these requirements.
+
+    `civi-download-tools` will attempt to identify and report common issues (such as missing/unknown commands).
+
+    For purposes of this developer documentation, we will assume that *one* development environment (host or VM or container) meets *all* system requirements.
+    This is not strictly required - as CiviCRM can be used in distributed deployments - but the constraint allows simpler workflows and documentation.
 
 ## Post-install configuration {:#config}
 


### PR DESCRIPTION
1. I believe the list of system requirements in `requirements.md` and `buildkit.md` were originally copied from the same place, but they've drifted apart arbitrarily.  This reconciles them by:
    
    * Copying some of the details in `buildkit.md` over to `requirements.md`
    * Removing the list from `buildkit.md`
    * Replacing with a hyperlink and a blurb about the importance of system requirements
    
2. When reading the "Generic" section, my eyes glazed over at the list of requirements.  There are really just two instructions (`git clone...` and `./bin/civi-download-tools`). Considering that `civi-download-tools` has some diagnostics built-in (and is patch-welcome for more), it seems to belabor the point by reproducing the entire list under `buildkit.md#other-platforms`.

