### PR TITLE
api/*/changes.md - Fix broken link that blocks publication

### DIFF
--- a/docs/api/v3/changes.md
+++ b/docs/api/v3/changes.md
@@ -2,7 +2,7 @@
 
 *This page lists additions to the APIv3 with each new release of CiviCRM Core.*
 
-Also see: [Differences Between Api v3 and v4](/api/v4/differences-with-v3.md) and [Hooks Changelog](hooks/changes.md).
+Also see: [Differences Between Api v3 and v4](/api/v4/differences-with-v3.md) and [Hooks Changelog](/hooks/changes.md).
 
 ## APIv3: Framework
 

--- a/docs/api/v4/changes.md
+++ b/docs/api/v4/changes.md
@@ -2,7 +2,7 @@
 
 *This page lists additions to the APIv4 with each new release of CiviCRM Core.*
 
-Also see: [Differences Between Api v3 and v4](/api/v4/differences-with-v3.md) and [Hooks Changelog](hooks/changes.md).
+Also see: [Differences Between Api v3 and v4](/api/v4/differences-with-v3.md) and [Hooks Changelog](/hooks/changes.md).
 
 ## CiviCRM 5.23
 


### PR DESCRIPTION
I noticed that some recent merges weren't showing up on `docs.civicrm.org`.

This appears to because a hyperlink isn't quite formed properly. Locally, this shows up as

```
[bknix-max:~/src/civicrm-dev-docs] mkdocs serve
INFO    -  Building documentation...
INFO    -  Cleaning site directory
WARNING -  The page "api/v4/changes.md" contained a hyperlink to "api/v4/hooks/changes.md" which is not listed in the "pages" configuration.
WARNING -  The page "api/v3/changes.md" contained a hyperlink to "api/v3/hooks/changes.md" which is not listed in the "pages" configuration.
```

Also, if I navigate to `https://docs.civicrm.org/admin/publish/{book}` (where `{book}` is `dev`) and check the `prod.log`, it shows the same messages (but escalated from `WARNING` to `ERROR`).

```
[2020-03-02 23:27:54] request.CRITICAL: Uncaught PHP Exception Exception: "Build errors encountered. Book not published. Build error: 'MkDocs was unable to build the book. MkDocs command output: INFO    -  Cleaning site directory  INFO    -  Building documentation to directory: /var/www/civicrm-docs/var/cache/prod/publishing/publish_dev_en_1583191662  ERROR   -  Error building page api/v4/changes.md  Error: The page "api/v4/changes.md" contained a hyperlink to "api/v4/hooks/changes.md" which is not listed in the "pages" configuration. '" at /var/www/civicrm-docs/src/AppBundle/Utils/Publisher.php line 327 {"exception":"[object] (Exception(code: 0): Build errors encountered. Book not published. Build error: 'MkDocs was unable to build the book. MkDocs command output: INFO    -  Cleaning site directory \nINFO    -  Building documentation to directory: /var/www/civicrm-docs/var/cache/prod/publishing/publish_dev_en_1583191662 \nERROR   -  Error building page api/v4/changes.md \nError: The page \"api/v4/changes.md\" contained a hyperlink to \"api/v4/hooks/changes.md\" which is not listed in the \"pages\" configuration.\n' at /var/www/civicrm-docs/src/AppBundle/Utils/Publisher.php:327)"} []
```

This fixes the warnings locally; hopefully it fixes the publisher too.