### PR TITLE
Update hook reference to make it clear that cidRefs is deprecated

### DIFF
--- a/docs/hooks/hook_civicrm_merge.md
+++ b/docs/hooks/hook_civicrm_merge.md
@@ -19,7 +19,7 @@ hook_civicrm_merge($type, &$data, $mainId = NULL, $otherId = NULL, $tables = NUL
 ## Parameters
 
 -   string `$type` - the type of data being passed
-    (`cidRefs`, `eidRefs`, `relTables`, or `sqls`)
+    (`cidRefs` (deprecated, hook will no longer be called at some point for this), `eidRefs`, `relTables`, or `sqls`)
 -   array `$data` - the data, which depends on the value of `$type` (see Details)
 -   int `$mainId` - ID of the contact that survives the merge (only
     when `$type` is `sqls`)
@@ -51,6 +51,7 @@ passed:
     merge operation.  These SQL statements are run within a single transaction.
 
 -   `cidRefs`:
+    this is deprecated in favour of the entityTypes hook. If you alter cidRefs you will get a deprecation warning
     an array of tables and their fields referencing
     civicrm_contact.contact_id explicitly.  Each table in the array has this format:
 
@@ -106,10 +107,7 @@ function civitest_civicrm_merge($type, &$data, $mainId = NULL, $otherId = NULL, 
       break;
 
     case 'cidRefs':
-      // Add references to civitest_foo.contact_id, and civitest_foo.foo_id, both of which
-      // are foreign keys to civicrm_contact.id.  By adding this to $data, records in this
-      // table will be automatically included in the merge.
-      $data[$db_default . 'civitest_foo'] = array('contact_id', 'foo_id');
+      // Use entityTypes hook instead as cidRefs is deprecated in this hook.
       break;
 
     case 'eidRefs':


### PR DESCRIPTION
We deprecated altering the data from the hook when called with cidRefs over a year ago but docs were not updated

<img width="942" alt="Screen Shot 2020-04-08 at 12 55 45 PM" src="https://user-images.githubusercontent.com/336308/78735357-be234e80-799e-11ea-94e6-37d01a972c22.png">
