### PR TITLE
dev/core#1744 - Cleanup event naming

### DIFF
--- a/docs/framework/token.md
+++ b/docs/framework/token.md
@@ -93,7 +93,7 @@ The basic process in the new subsystem is
 
 - Whenever an application's controller (e.g. for CiviMail or PDFs or scheduled reminders) needs to compose a message, it instantiates `Civi\Token\TokenProcessor`.
 - The `controller` passes some information to `TokenProcessor` – namely, the `$context` and the list of `$rows`.
-- The `TokenProcessor` fires an event (`TOKEN_EVALUATE`). Other modules respond with the actual token content.
+- The `TokenProcessor` fires an event (`civi.token.eval`). Other modules respond with the actual token content.
 - For each of the rows, the controller requests a rendered blob of text.
 
 ```php
@@ -139,10 +139,10 @@ If a use-case builds on the newer `TokenProcessor` (above), then an additional A
 function example_civicrm_container($container) {
   $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
   $container->findDefinition('dispatcher')->addMethodCall('addListener',
-    array(\Civi\Token\Events::TOKEN_REGISTER, 'example_register_tokens')
+    ['civi.token.list', 'example_register_tokens']
   );
   $container->findDefinition('dispatcher')->addMethodCall('addListener',
-    array(\Civi\Token\Events::TOKEN_EVALUATE, 'example_evaluate_tokens')
+    ['civi.token.eval', 'example_evaluate_tokens']
   );
 }
 


### PR DESCRIPTION
This replaces event-name-constants with event-name-strings. See also:

* https://lab.civicrm.org/dev/core/-/issues/1744
* https://github.com/civicrm/civicrm-core/pull/17240